### PR TITLE
Import the lodash library to be able to use it

### DIFF
--- a/routes/api/v1.js
+++ b/routes/api/v1.js
@@ -4,6 +4,7 @@ var base        = require('taskcluster-base');
 var slugid      = require('slugid');
 var azureTable  = require('azure-table-node');
 var Promise     = require('promise');
+var _           = require('lodash');
 
 /** API end-point for version v1/ */
 var api = new base.API({


### PR DESCRIPTION
bug 1123681 -- without this, we cannot call createClient()