### PR TITLE
Bug 1137740: limit temporary credentials, use client role

### DIFF
--- a/auth/persona.js
+++ b/auth/persona.js
@@ -29,8 +29,11 @@ var renderIndex = async function(authFailed, req, res) {
     });
     credentials = taskcluster.createTemporaryCredentials({
       start:        new Date(),
-      expiry:       new Date(new Date().getTime() + 31 * 24 * 60 * 60 * 1000),
-      scopes:       client.expandedScopes(),
+      // good for three days
+      expiry:       new Date(new Date().getTime() + 3 * 24 * 60 * 60),
+      // use the client's role without expanding them, so that the temporary
+      // credentials track changes to roles
+      scopes:       ['assume:client-id:' + client.clientId],
       credentials:  {
         clientId:     client.clientId,
         accessToken:  client.accessToken

--- a/views/login.jade
+++ b/views/login.jade
@@ -31,19 +31,17 @@ html(lang='en')
         hr
         p
           | Welcome to TaskCluster authentication interface. This site allows
-          | you to authentication against TaskCluster using Persona with an
+          | you to authenticate to TaskCluster using Persona with an
           | &nbsp;
           code @mozilla.com
           | address. Once authenticated you'll be issued a set of temporary
-          | TaskCluster credentials that will remain valid for 31 days. If you
-          | where redirected here from another site, you'll be offered the
+          | TaskCluster credentials that will remain valid for 3 days. If you
+          | were redirected here from another site, you'll be offered the
           | option of redirecting back to the orignal site with credentials as
           | query string (assuming you want to delegate access).
         p
           b Note,&nbsp;
-          | we are working to allow authentication with any mozillians.org
-          | account. But this maybe take a while, pending API additions to
-          | mozillians.org.
+          | we are working hard on a better system.
         br
         h2 Temporary Credentials
         hr


### PR DESCRIPTION
This limits the creds' lifetime to 3 days, and uses the `client-id:..`
role explicitly so that as the clientId's scopes change, so do the
temporary credentials.