### PR TITLE
[DO NOT MERGE] Use resolver cache

### DIFF
--- a/auth/data.js
+++ b/auth/data.js
@@ -83,7 +83,7 @@ Client.ensureRootClient = function(accessToken) {
   // Create client resolving conflicts by overwriting
   return Client.create({
     clientId:         'root',
-    description:      "Automatically created `root` client " +
+    description:      "Automatically created `root` client with star scopes " +
                       "for bootstrapping API access",
     accessToken:      accessToken,
     expires:          taskcluster.fromNow('24 hours'),
@@ -93,7 +93,7 @@ Client.ensureRootClient = function(accessToken) {
       lastDateUsed:   new Date().toJSON(),
       lastRotated:    new Date().toJSON()
     },
-    scopes:           [],
+    scopes:           ['*'],
     disabled:         0,
   }, true);
 };
@@ -135,29 +135,6 @@ Role.prototype.json = function() {
     scopes:         this.scopes,
     expandedScopes: this.resolver.resolve(scopes),
   };
-};
-
-/**
- * Ensure the role: client-id:root -> ['*'] exists
- *
- * Should only be called if the app is configured with a rootAccessToken.
- * Otherwise, app should assume whatever is in the table storage is the
- * root access token, and that appropriate role is attached.
- *
- * Basically, this is for bootstrapping only.
- */
-Role.ensureRootRole = function() {
-  let Role = this;
-  return Role.create({
-    roleId:       'client-id:root',
-    description:  "Automatically created role for bootstrapping the `root` "+
-                  "client.",
-    scopes:       ['*'],
-    details: {
-      created:        new Date().toJSON(),
-      lastModified:   new Date().toJSON()
-    }
-  }, true);
 };
 
 // Export Role

--- a/auth/data.js
+++ b/auth/data.js
@@ -14,6 +14,17 @@ var Client = Entity.configure({
     description:    Entity.types.Text,
     accessToken:    Entity.types.EncryptedText,
     expires:        Entity.types.Date,
+    details:        Entity.types.JSON
+  },
+  context:          ['resolver']
+}).configure({
+  version:          2,
+  signEntities:     true,
+  properties: {
+    clientId:       Entity.types.String,
+    description:    Entity.types.Text,
+    accessToken:    Entity.types.EncryptedText,
+    expires:        Entity.types.Date,
     /**
      * Details object with properties:
      * - created          // Time when client was created
@@ -22,14 +33,24 @@ var Client = Entity.configure({
      * - lastRotated      // Last time accessToken was reset
      * (more properties may be added in the future)
      */
-    details:        Entity.types.JSON
+    details:        Entity.types.JSON,
+    scopes:         Entity.types.JSON,  // new in v2
+    disabled:       Entity.types.Number // new in v2
   },
-  context:          ['resolver']
+  context:          ['resolver'],
+  migrate(item) {
+    item.scopes = [];
+    item.disabled = false;
+    return item;
+  }
 });
 
 /** Get scopes granted to this client */
 Client.prototype.expandedScopes = function() {
-  return this.resolver.resolve(['assume:client-id:' + this.clientId]);
+  return this.resolver.resolve(
+      // resolve the client's scopes plus the client-id role
+      this.scopes.concat(['assume:client-id:' + this.clientId])
+    );
 };
 
 /** Get JSON representation of client */
@@ -42,7 +63,9 @@ Client.prototype.json = function() {
     lastModified:   this.details.lastModified,
     lastDateUsed:   this.details.lastDateUsed,
     lastRotated:    this.details.lastRotated,
-    expandedScopes: this.expandedScopes()
+    scopes:         this.scopes,
+    expandedScopes: this.expandedScopes(),
+    disabled:       !!this.disabled
   };
 };
 
@@ -69,7 +92,9 @@ Client.ensureRootClient = function(accessToken) {
       lastModified:   new Date().toJSON(),
       lastDateUsed:   new Date().toJSON(),
       lastRotated:    new Date().toJSON()
-    }
+    },
+    scopes:           [],
+    disabled:         0,
   }, true);
 };
 

--- a/auth/scoperesolver.js
+++ b/auth/scoperesolver.js
@@ -21,12 +21,14 @@ class ScopeResolver extends events.EventEmitter {
     assert(/^ *-/.test(options.maxLastUsedDelay),
            'maxLastUsedDelay must be negative');
 
-    // List of client objects on the form:
+    // List of enabled client objects on the form:
     // {
     //    clientId, accessToken,
+    //    scopes: [...],                // Scopes (as set in the table)
     //    expandedScopes: [...],        // Scopes (including indirect scopes)
     //    updateLastUsed: true | false  // true, if lastUsed should be updated
     // }
+    // disabled clients are excluded from this list.
     this._clients = [];
     // List of role objects on the form:
     // {roleId: '...', scopes: [...], expandedScopes: [...]}
@@ -125,15 +127,16 @@ class ScopeResolver extends events.EventEmitter {
       let client = await this._Client.load({clientId}, true);
       // Always remove it
       this._clients = this._clients.filter(c => c.clientId !== clientId);
-      // If a client was loaded add it back
-      if (client) {
+      // If a client was loaded and not disabled, add it back
+      if (client && !client.disabled) {
         // For reasoning on structure, see reload()
         let lastUsedDate = new Date(client.details.lastDateUsed);
         let minLastUsed = taskcluster.fromNow(this._maxLastUsedDelay);
         this._clients.push({
           clientId:       client.clientId,
           accessToken:    client.accessToken,
-          updateLastUsed: lastUsedDate < minLastUsed
+          updateLastUsed: lastUsedDate < minLastUsed,
+          scopes:         client.scopes
         });
       }
       this._computeFixedPoint();
@@ -171,6 +174,9 @@ class ScopeResolver extends events.EventEmitter {
         // _computeFixedPoint() will construct the `_clientCache` object
         this._Client.scan({}, {
           handler: client => {
+            if (client.disabled) {
+              return;
+            }
             let lastUsedDate = new Date(client.details.lastDateUsed);
             let minLastUsed = taskcluster.fromNow(this._maxLastUsedDelay);
             clients.push({
@@ -179,7 +185,8 @@ class ScopeResolver extends events.EventEmitter {
               // Note that lastUsedDate should be updated, if it's out-dated by
               // more than 6 hours.
               // (cheap way to know if it's been used recently)
-              updateLastUsed: lastUsedDate < minLastUsed
+              updateLastUsed: lastUsedDate < minLastUsed,
+              scopes:         client.scopes
             });
           }
         }),
@@ -221,7 +228,8 @@ class ScopeResolver extends events.EventEmitter {
     // Construct client cache
     this._clientCache = {};
     for (let client of this._clients) {
-      var scopes = this.resolve(['assume:client-id:' + client.clientId]);
+      var scopes = this.resolve(
+          ['assume:client-id:' + client.clientId].concat(client.scopes));
       client.scopes = scopes; // for createSignatureValidator compatibility
       client.expandedScopes = scopes;
       this._clientCache[client.clientId] = client;

--- a/auth/v1.js
+++ b/auth/v1.js
@@ -108,14 +108,8 @@ api.declare({
     "Get a list of all clients."
   ].join('\n')
 }, async function(req, res) {
-
-  // Load all clients
-  let clients = [];
-  await this.Client.scan({}, {
-    handler: client => clients.push(client.json())
-  });
-
-  res.reply(clients);
+  // take advantage of the resolver's cache
+  res.reply(this.resolver.jsonClients());
 });
 
 
@@ -134,14 +128,14 @@ api.declare({
 }, async function(req, res) {
   let clientId = req.params.clientId;
 
-  // Load client
-  let client = await this.Client.load({clientId}, true);
+  // Load client from the resolver's cache
+  let client = this.resolver.jsonClient(clientId);
 
   if (!client) {
     return res.status(404).json({message: "Client not found!"});
   }
 
-  res.reply(client.json());
+  res.reply(client);
 });
 
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -139,7 +139,6 @@ let load = loader({
       // set up the root access token if necessary
       if (cfg.get('auth:rootAccessToken')) {
         await Client.ensureRootClient(cfg.get('auth:rootAccessToken'));
-        await Role.ensureRootRole();
       }
 
       // Load everything for resolver

--- a/schemas/create-client-request.yml
+++ b/schemas/create-client-request.yml
@@ -15,6 +15,16 @@ properties:
       Should include who is the owner, point of contact.
     type:                   string
     maxLength:              10240
+  scopes:
+    description: |
+      List of scopes the client has.  Scopes must be composed of
+      printable ASCII characters and spaces.
+    type:                   array
+    items:
+      description: Scope
+      type:                 string
+      pattern: "^[\x20-\x7e]*$"
+    uniqueItems:            true
 additionalProperties:       false
 required:
   - expires

--- a/schemas/create-client-response.yml
+++ b/schemas/create-client-response.yml
@@ -49,16 +49,32 @@ properties:
       Date and time of when the `accessToken` was reset last time.
     type:                   string
     format:                 date-time
+  scopes:
+    description: |
+      List of scopes the client has (unexpanded).  Scopes must be composed of
+      printable ASCII characters and spaces.
+    type:                   array
+    default:                []
+    items:
+      description: Scope
+      type:                 string
+      pattern: "^[\x20-\x7e]*$"
+    uniqueItems:            true
   expandedScopes:
     description: |
-      List of scopes granted to this client by matching roles.  Scopes must be
-      composed of printable ASCII characters and spaces.
+      List of scopes granted to this client by matching roles, including the
+      client's scopes and the implicit role `client-id:<clientId>`.
     type:                   array
     items:
       description: |
-        Scope that client is granted by a role
+        Scope that client is granted
       type:                 string
       pattern: "^[\x20-\x7e]*$"
+  disabled:
+    description: |
+      If true, this client is disabled and cannot be used.  This usually occurs when the
+      scopes avaialble to the user owning the client no longer satisfy the client.
+    type: boolean
 additionalProperties:       false
 required:
   - clientId
@@ -69,4 +85,6 @@ required:
   - lastModified
   - lastDateUsed
   - lastRotated
+  - scopes
   - expandedScopes
+  - disabled

--- a/schemas/get-client-response.yml
+++ b/schemas/get-client-response.yml
@@ -43,6 +43,17 @@ properties:
       Date and time of when the `accessToken` was reset last time.
     type:                   string
     format:                 date-time
+  scopes:
+    description: |
+      List of scopes the client has (unexpanded).  Scopes must be composed of
+      printable ASCII characters and spaces.
+    type:                   array
+    default:                []
+    items:
+      description: Scope
+      type:                 string
+      pattern: "^[\x20-\x7e]*$"
+    uniqueItems:            true
   expandedScopes:
     description: |
       List of scopes granted to this client by matching roles.  Scopes must be
@@ -53,6 +64,11 @@ properties:
         Scope that client is granted by a role
       type:                 string
       pattern:              "^[\x20-\x7e]*$"
+  disabled:
+    description: |
+      If true, this client is disabled and cannot be used.  This usually occurs when the
+      scopes avaialble to the user owning the client no longer satisfy the client.
+    type: boolean
 additionalProperties:       false
 required:
   - clientId
@@ -62,4 +78,6 @@ required:
   - lastModified
   - lastDateUsed
   - lastRotated
+  - scopes
   - expandedScopes
+  - disabled

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -53,7 +53,7 @@ suite('api (client)', function() {
     });
   });
 
-  test("auth.createClient", async () => {
+  test("auth.createClient (no scopes)", async () => {
     await helper.events.listenFor('e1', helper.authEvents.clientCreated({
       clientId:  CLIENT_ID
     }));
@@ -73,6 +73,43 @@ suite('api (client)', function() {
     assume(client2.description).equals(description);
     assume(client2.expires).equals(expires.toJSON());
     assume(client2).has.not.own('accessToken');
+    assume(client2.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
+
+    await helper.events.waitFor('e1');
+  });
+
+  test("auth.createClient (with scopes)", async () => {
+    await helper.auth.deleteClient(CLIENT_ID);
+
+    await helper.events.listenFor('e1', helper.authEvents.clientCreated({
+      clientId:  CLIENT_ID
+    }));
+
+    var expires = new Date();
+    var description = "Test client...";
+    var scopes = ["scope1", "scope2"];
+    let client = await helper.auth.createClient(CLIENT_ID, {
+      expires, description, scopes,
+    });
+    assume(client.description).equals(description);
+    assume(client.expires).equals(expires.toJSON());
+    assume(client.accessToken).is.a('string');
+    assume(client.scopes).contains('scope1');
+    assume(client.scopes).contains('scope2');
+    assume(client.scopes).not.contains('assume:client-id:' + CLIENT_ID);
+    assume(client.expandedScopes).contains('scope1');
+    assume(client.expandedScopes).contains('scope2');
+    assume(client.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
+
+    let client2 = await helper.auth.client(CLIENT_ID);
+    assume(client2.description).equals(description);
+    assume(client2.expires).equals(expires.toJSON());
+    assume(client2).has.not.own('accessToken');
+    assume(client2.scopes).contains('scope1');
+    assume(client2.scopes).contains('scope2');
+    assume(client2.scopes).not.contains('assume:client-id:' + CLIENT_ID);
+    assume(client2.expandedScopes).contains('scope1');
+    assume(client2.expandedScopes).contains('scope2');
     assume(client2.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
 
     await helper.events.waitFor('e1');
@@ -145,7 +182,7 @@ suite('api (client)', function() {
     await helper.auth.deleteRole('client-id:' + CLIENT_ID);
   });
 
-  test("auth.updateClient", async () => {
+  test("auth.updateClient (no scope changes)", async () => {
     await helper.events.listenFor('e1', helper.authEvents.clientUpdated({
       clientId:  CLIENT_ID
     }));
@@ -160,14 +197,55 @@ suite('api (client)', function() {
     assume(new Date(client.lastModified).getTime())
       .is.greaterThan(new Date(client.lastRotated).getTime());
     assume(client).has.not.own('accessToken');
+    assume(client.scopes).contains('scope1');
+    assume(client.scopes).contains('scope2');
     assume(client.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
     await helper.events.waitFor('e1');
 
     let client2 = await helper.auth.client(CLIENT_ID);
     assume(client2.lastModified).equals(client.lastModified);
     assume(client2).has.not.own('accessToken');
+    assume(client2.scopes).contains('scope1');
+    assume(client2.scopes).contains('scope2');
+    assume(client2.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
   });
 
+  test("auth.updateClient (with scope changes)", async () => {
+    await helper.events.listenFor('e1', helper.authEvents.clientUpdated({
+      clientId:  CLIENT_ID
+    }));
+
+    var expires = new Date();
+    let description = 'Third test description...';
+    let scopes = ['scope2', 'scope3'];
+    let client = await helper.auth.updateClient(CLIENT_ID, {
+      description, expires, scopes
+    });
+    assume(client.description).equals(description);
+    assume(client.expires).equals(expires.toJSON());
+    assume(new Date(client.lastModified).getTime())
+      .is.greaterThan(new Date(client.lastRotated).getTime());
+    assume(client).has.not.own('accessToken');
+    assume(client.scopes).not.contains('scope1');
+    assume(client.scopes).contains('scope2');
+    assume(client.scopes).contains('scope3');
+    assume(client.expandedScopes).not.contains('scope1');
+    assume(client.expandedScopes).contains('scope2');
+    assume(client.expandedScopes).contains('scope3');
+    assume(client.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
+    await helper.events.waitFor('e1');
+
+    let client2 = await helper.auth.client(CLIENT_ID);
+    assume(client2.lastModified).equals(client.lastModified);
+    assume(client2).has.not.own('accessToken');
+    assume(client2.scopes).not.contains('scope1');
+    assume(client2.scopes).contains('scope2');
+    assume(client2.scopes).contains('scope3');
+    assume(client2.expandedScopes).not.contains('scope1');
+    assume(client2.expandedScopes).contains('scope2');
+    assume(client2.expandedScopes).contains('scope3');
+    assume(client2.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
+  });
 
   test("auth.deleteClient", async () => {
     await helper.events.listenFor('e1', helper.authEvents.clientDeleted({

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -247,6 +247,24 @@ suite('api (client)', function() {
     assume(client2.expandedScopes).contains('assume:client-id:' + CLIENT_ID);
   });
 
+  test("auth.disableClient", async () => {
+    let client = await helper.auth.disableClient(CLIENT_ID);
+    assume(client.disabled).equals(true);
+    client = await helper.auth.client(CLIENT_ID);
+    assume(client.disabled).equals(true);
+    client = await helper.auth.disableClient(CLIENT_ID);
+    assume(client.disabled).equals(true);
+  });
+
+  test("auth.enableClient", async () => {
+    let client = await helper.auth.enableClient(CLIENT_ID);
+    assume(client.disabled).equals(false);
+    client = await helper.auth.client(CLIENT_ID);
+    assume(client.disabled).equals(false);
+    client = await helper.auth.enableClient(CLIENT_ID);
+    assume(client.disabled).equals(false);
+  });
+
   test("auth.deleteClient", async () => {
     await helper.events.listenFor('e1', helper.authEvents.clientDeleted({
       clientId:  CLIENT_ID

--- a/test/rolelogic_test.js
+++ b/test/rolelogic_test.js
@@ -396,13 +396,17 @@ suite('api (role logic)', function() {
       {
         roleId: 'client-id:test-client-1',
         scopes: ['a*']
+      },
+      {
+        roleId: 'star',
+        scopes: ['*']
       }
     ],
     clients: [
       {
         clientId:   'test-client-1',
         includes: [
-          '*'       // because assume:client-id:root is granted
+          '*'       // because assume:star is granted
         ],
         excludes: [
           'scope-1', 'scope-2'
@@ -416,13 +420,17 @@ suite('api (role logic)', function() {
       {
         roleId: 'client-id:test-client-1',
         scopes: ['assume*']
+      },
+      {
+        roleId: 'star',
+        scopes: ['*']
       }
     ],
     clients: [
       {
         clientId:   'test-client-1',
         includes: [
-          '*'       // because assume:client-id:root is granted
+          '*'       // because assume:star is granted
         ],
         excludes: [
           'scope-1', 'scope-2'
@@ -436,13 +444,17 @@ suite('api (role logic)', function() {
       {
         roleId: 'client-id:test-client-1',
         scopes: ['assume:*']
+      },
+      {
+        roleId: 'star',
+        scopes: ['*']
       }
     ],
     clients: [
       {
         clientId:   'test-client-1',
         includes: [
-          '*'       // because assume:client-id:root is granted
+          '*'       // because assume:star is granted
         ],
         excludes: [
           'scope-1', 'scope-2'
@@ -455,14 +467,18 @@ suite('api (role logic)', function() {
     roles: [
       {
         roleId: 'client-id:test-client-1',
-        scopes: ['assume:client-*']
+        scopes: ['assume:st*']
+      },
+      {
+        roleId: 'star',
+        scopes: ['*']
       }
     ],
     clients: [
       {
         clientId:   'test-client-1',
         includes: [
-          '*'       // because assume:client-id:root is granted
+          '*'       // because assume:star is granted
         ],
         excludes: [
           'scope-1', 'scope-2'

--- a/test/schemas/create-client-request-no-scopes.json
+++ b/test/schemas/create-client-request-no-scopes.json
@@ -1,0 +1,4 @@
+{
+  "expires": "2000-02-01 00:00:00",
+  "description": "Simple"
+}

--- a/test/schemas/create-client-request-with-scopes.json
+++ b/test/schemas/create-client-request-with-scopes.json
@@ -1,0 +1,5 @@
+{
+  "expires": "2000-02-01 00:00:00",
+  "scopes": ["ab.cd"],
+  "description": "Simple"
+}

--- a/test/stories_test.js
+++ b/test/stories_test.js
@@ -21,7 +21,7 @@ suite('user stories', function() {
     var identityProvider,
         identityProviderToken,
         charlene,
-        travis_tests;
+        travisTests;
 
     test("add a client for the identity provider", async () => {
       let idp = await helper.auth.createClient('test-users', {
@@ -31,6 +31,7 @@ suite('user stories', function() {
           'auth:create-client:test-users/*',
           'auth:update-client:test-users/*',
           'auth:enable-client:test-users/*',
+          'auth:disable-client:test-users/*',
           'auth:delete-client:test-users/*',
           'auth:reset-access-token:test-users/*',
           'assume:test-role:*',
@@ -75,12 +76,19 @@ suite('user stories', function() {
     });
 
     test("charlene creates permanent credentials for her tests", async () => {
-      travis_tests = await charlene.createClient('test-users/charlene/travis-tests', {
+      let travisClient = await charlene.createClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"), // N.B. longer than temp creds
         scopes: [
           'assume:test-role:role1',
         ],
+      });
+
+      travisTests = new helper.Auth({
+        credentials: {
+          clientId: 'test-users/charlene/travis-tests',
+          accessToken: travisClient.accessToken
+        }
       });
     });
 
@@ -88,7 +96,7 @@ suite('user stories', function() {
 
     test("charlene tries to grant role3 (which she does not have) to her client", async () => {
       try {
-        travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+        await charlene.updateClient('test-users/charlene/travis-tests', {
           description: "Permacred created by test",
           expires: taskcluster.fromNow("3 hours"),
           scopes: [
@@ -103,17 +111,18 @@ suite('user stories', function() {
     });
 
     test("charlene grants role2 and removes role1", async () => {
-      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+      let newClient = await charlene.updateClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"),
         scopes: [
           'assume:test-role:role2',
         ],
       });
+      assume(newClient.scopes).to.contain('assume:test-role:role2');
     });
 
     test("root grants role3", async () => {
-      travis_tests = await helper.auth.updateClient('test-users/charlene/travis-tests', {
+      let newClient = await helper.auth.updateClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"),
         scopes: [
@@ -124,7 +133,7 @@ suite('user stories', function() {
     });
 
     test("charlene revokes role3", async () => {
-      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+      let newClient = await charlene.updateClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"),
         scopes: [
@@ -134,7 +143,7 @@ suite('user stories', function() {
     });
 
     test("root grants role3 again", async () => {
-      travis_tests = await helper.auth.updateClient('test-users/charlene/travis-tests', {
+      let newClient = await helper.auth.updateClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"),
         scopes: [
@@ -145,7 +154,7 @@ suite('user stories', function() {
 
     // TODO: bug 1242473
     test.skip("charlene replaces role3 with one of its constituent scopes", async () => {
-      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+      let newClient = await charlene.updateClient('test-users/charlene/travis-tests', {
         description: "Permacred created by test",
         expires: taskcluster.fromNow("3 hours"),
         scopes: [
@@ -153,5 +162,37 @@ suite('user stories', function() {
         ],
       });
     });
+
+    test("A disabled travis-tests client can't do things anymore", async function() {
+      // give the user a scope we can use as a probe
+      await helper.auth.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'auth:delete-client:test-users/charlene/travis-tests/*',
+        ],
+      });
+
+      // should succeed
+      await travisTests.deleteClient('test-users/charlene/travis-tests/foo');
+
+      // disable
+      await identityProvider.disableClient('test-users/charlene/travis-tests');
+
+      // should fail
+      await travisTests.deleteClient('test-users/charlene/travis-tests/foo').then(() => {
+        assert(false, "expected an error!");
+      }, err => {
+        assert(err.statusCode === 401, "expected 401");
+      });
+
+      // enable
+      await identityProvider.enableClient('test-users/charlene/travis-tests');
+
+      // should succeed
+      await travisTests.deleteClient('test-users/charlene/travis-tests/foo');
+    });
+
   });
 });
+

--- a/test/stories_test.js
+++ b/test/stories_test.js
@@ -1,0 +1,157 @@
+suite('user stories', function() {
+  var Promise     = require('promise');
+  var assert      = require('assert');
+  var debug       = require('debug')('test:client');
+  var helper      = require('./helper');
+  var slugid      = require('slugid');
+  var _           = require('lodash');
+  var assume      = require('assume');
+  var base        = require('taskcluster-base');
+  var taskcluster = require('taskcluster-client');
+
+  suite("charlene creates permanent credentials for a test runner", function() {
+    let cleanup = async () => {
+      await helper.auth.deleteRole('client-id:test-users/test');
+      await helper.auth.deleteClient('test-users');
+      await helper.auth.deleteClient('test-users/charlene/travis-tests');
+    };
+    before(cleanup);
+
+    // NOTE: these tests run in order
+    var identityProvider,
+        identityProviderToken,
+        charlene,
+        travis_tests;
+
+    test("add a client for the identity provider", async () => {
+      let idp = await helper.auth.createClient('test-users', {
+        description: "Test users identity provider",
+        expires: taskcluster.fromNow("2 hours"),
+        scopes: [
+          'auth:create-client:test-users/*',
+          'auth:update-client:test-users/*',
+          'auth:enable-client:test-users/*',
+          'auth:delete-client:test-users/*',
+          'auth:reset-access-token:test-users/*',
+          'assume:test-role:*',
+        ],
+      });
+
+      identityProviderToken = idp.accessToken;
+      identityProvider = new helper.Auth({
+        credentials: {
+          clientId: 'test-users',
+          accessToken: identityProviderToken
+        }
+      });
+    });
+
+    test("add role3", async () => {
+      await helper.auth.createRole('test-role:role3', {
+        description: "role 3",
+        scopes: ['scope3a', 'scope3b'],
+      });
+    });
+
+    test("create temporary credentials for charlene's browser login", async () => {
+      charlene = new helper.Auth({
+        credentials: taskcluster.createTemporaryCredentials({
+          start: new Date(),
+          expiry: taskcluster.fromNow("1 hour"),
+          credentials: {
+            clientId: 'test-users',
+            accessToken: identityProviderToken
+          },
+          scopes: [
+            'auth:create-client:test-users/charlene/*',
+            'auth:update-client:test-users/charlene/*',
+            'auth:delete-client:test-users/charlene/*',
+            'auth:reset-access-token:test-users/charlene/*',
+            'assume:test-role:role1',
+            'assume:test-role:role2',
+          ],
+        }),
+      });
+    });
+
+    test("charlene creates permanent credentials for her tests", async () => {
+      travis_tests = await charlene.createClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"), // N.B. longer than temp creds
+        scopes: [
+          'assume:test-role:role1',
+        ],
+      });
+    });
+
+    // test some access-control
+
+    test("charlene tries to grant role3 (which she does not have) to her client", async () => {
+      try {
+        travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+          description: "Permacred created by test",
+          expires: taskcluster.fromNow("3 hours"),
+          scopes: [
+            'assume:test-role:role1',
+            'assume:test-role:role3',
+          ],
+        });
+        throw new Error("did not get expected error");
+      } catch (err) {
+        assume(err.statusCode).to.equal(401);
+      }
+    });
+
+    test("charlene grants role2 and removes role1", async () => {
+      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'assume:test-role:role2',
+        ],
+      });
+    });
+
+    test("root grants role3", async () => {
+      travis_tests = await helper.auth.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'assume:test-role:role2',
+          'assume:test-role:role3',
+        ],
+      });
+    });
+
+    test("charlene revokes role3", async () => {
+      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'assume:test-role:role2',
+        ],
+      });
+    });
+
+    test("root grants role3 again", async () => {
+      travis_tests = await helper.auth.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'assume:test-role:role3',
+        ],
+      });
+    });
+
+    // TODO: bug 1242473
+    test.skip("charlene replaces role3 with one of its constituent scopes", async () => {
+      travis_tests = await charlene.updateClient('test-users/charlene/travis-tests', {
+        description: "Permacred created by test",
+        expires: taskcluster.fromNow("3 hours"),
+        scopes: [
+          'scope3a',
+        ],
+      });
+    });
+  });
+});

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -53,6 +53,14 @@ var testCases = [
     path:     'authenticate-hawk-request-bad.json',
     schema:   'auth/v1/authenticate-hawk-request.json#',
     success:  false
+  }, {
+    path:     'create-client-request-no-scopes.json',
+    schema:   'auth/v1/create-client-request.json#',
+    success:  true
+  }, {
+    path:     'create-client-request-with-scopes.json',
+    schema:   'auth/v1/create-client-request.json#',
+    success:  true
   }
 ];
 


### PR DESCRIPTION
This is an offshoot of #34 that switches `client` and `listClients` to read from the resolver's cache rather than from the Azure tables.  In that PR, we decided not to do this yet, as it introduces the possibility of serving stale data from these requests.
