### PR TITLE
handle missing config a little better

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -23,7 +23,7 @@ let load = loader({
   drain: {
     requires: ['cfg'],
     setup: ({cfg}) => {
-      if (cfg.influx.connectionString) {
+      if (cfg.influx && cfg.influx.connectionString) {
         return new base.stats.Influx(cfg.influx);
       }
       return new base.stats.NullDrain();
@@ -51,7 +51,7 @@ let load = loader({
     setup: ({cfg, drain, resolver}) =>
       data.Client.setup({
         table:        cfg.app.clientTableName,
-        credentials:  cfg.azure,
+        credentials:  cfg.azure || {},
         signingKey:   cfg.app.tableSigningKey,
         cryptoKey:    cfg.app.tableCryptoKey,
         drain:        drain,
@@ -66,7 +66,7 @@ let load = loader({
     setup: ({cfg, drain, resolver}) => 
       data.Role.setup({
         table:        cfg.app.rolesTableName,
-        credentials:  cfg.azure,
+        credentials:  cfg.azure || {},
         signingKey:   cfg.app.tableSigningKey,
         drain:        drain,
         component:    cfg.app.statsComponent,

--- a/test/helper.js
+++ b/test/helper.js
@@ -38,7 +38,7 @@ mocha.before(async () => {
   overwrites['profile'] = 'test';
 
   // if we don't have an azure account/key, use the inmemory version
-  if (!cfg.azure.accountName) {
+  if (!cfg.azure || !cfg.azure.accountName) {
     let resolver = await serverLoad('resolver', overwrites);
     let signingKey = cfg.app.tableSigningKey;
     let cryptoKey = cfg.app.tableCryptoKey;


### PR DESCRIPTION
With this, you can omit `influx` and `azure` from user-config.yml and still have things run.