### PR TITLE
Support named temporary credentials

### DIFF
--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -184,8 +184,10 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
  * The function returned takes an object:
  *     {method, resource, host, port, authorization}
  * And returns promise for an object on one of the forms:
- *     {status: 'auth-failed', message}, or
- *     {status: 'auth-success', clientId, scheme, scopes}
+ *     {status: 'auth-failed', message},
+ *     {status: 'auth-success', clientId, scheme, scopes}, or
+ *     {status: 'auth-success', clientId, scheme, scopes, hash}
+ * where `hash` is the payload hash.
  *
  * The `expandScopes` applies any rules that expands scopes, such as roles.
  * It is assumed that clients from `clientLoader` are returned with scopes

--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -87,15 +87,6 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
 
     // Check clientId validity
     if (issuingClientId !== credentialName) {
-      if (!cert.clientId) {
-        throw new Error('ext.certificate.clientId must be set when ext.certificate.issuer is given');
-      }
-      if (typeof(cert.clientId) !== 'string') {
-        throw new Error('ext.certificate.clientId must be a string');
-      }
-      if (cert.clientId !== credentialName) {
-        throw new Error('ext.certificate.clientId must match the supplied clientId');
-      }
       let createScope = 'auth:create-client:' + credentialName;
       if (!utils.scopeMatch(issuingScopes, [[createScope]])) {
         throw new Error("ext.certificate issuer `" + issuingClientId +
@@ -116,8 +107,8 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
     // Generate certificate signature
     var sigContent = []
     sigContent.push('version:'    + '1');
-    if (cert.clientId && cert.issuer) {
-      sigContent.push('clientId:' + cert.clientId);
+    if (cert.issuer) {
+      sigContent.push('clientId:' + credentialName);
       sigContent.push('issuer:'   + cert.issuer);
     }
     sigContent.push('seed:'       + cert.seed);
@@ -132,7 +123,11 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
     // Validate signature
     if (typeof(cert.signature) !== 'string' ||
         !cryptiles.fixedTimeComparison(cert.signature, signature)) {
-      throw new Error("ext.certificate.signature is not valid");
+      if (cert.issuer) {
+        throw new Error("ext.certificate.signature is not valid, or wrong clientId provided");
+      } else {
+        throw new Error("ext.certificate.signature is not valid");
+      }
     }
 
     // Regenerate temporary key

--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -87,14 +87,14 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
 
     // Check clientId validity
     if (issuingClientId !== credentialName) {
-      if (!cert.name) {
-        throw new Error('ext.certificate.name must be set when ext.certificate.issuer is given');
+      if (!cert.clientId) {
+        throw new Error('ext.certificate.clientId must be set when ext.certificate.issuer is given');
       }
-      if (typeof(cert.name) !== 'string') {
-        throw new Error('ext.certificate.name must be a string');
+      if (typeof(cert.clientId) !== 'string') {
+        throw new Error('ext.certificate.clientId must be a string');
       }
-      if (cert.name !== credentialName) {
-        throw new Error('ext.certificate.name must match the supplied clientId');
+      if (cert.clientId !== credentialName) {
+        throw new Error('ext.certificate.clientId must match the supplied clientId');
       }
       let createScope = 'auth:create-client:' + credentialName;
       if (!utils.scopeMatch(issuingScopes, [[createScope]])) {
@@ -102,8 +102,8 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
                         "` doesn't have `" + createScope + "` for supplied clientId.");
       }
     } else {
-      if (cert.hasOwnProperty('name')) {
-        throw new Error('ext.certificate.name must only be used with ext.certificate.issuer');
+      if (cert.hasOwnProperty('clientId')) {
+        throw new Error('ext.certificate.clientId must only be used with ext.certificate.issuer');
       }
     }
 
@@ -115,14 +115,14 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
 
     // Generate certificate signature
     var sigContent = []
-    sigContent.push('version:'  + '1');
-    if (cert.name && cert.issuer) {
-      sigContent.push('name:'   + cert.name);
-      sigContent.push('issuer:' + cert.issuer);
+    sigContent.push('version:'    + '1');
+    if (cert.clientId && cert.issuer) {
+      sigContent.push('clientId:' + cert.clientId);
+      sigContent.push('issuer:'   + cert.issuer);
     }
-    sigContent.push('seed:'     + cert.seed);
-    sigContent.push('start:'    + cert.start);
-    sigContent.push('expiry:'   + cert.expiry);
+    sigContent.push('seed:'       + cert.seed);
+    sigContent.push('start:'      + cert.start);
+    sigContent.push('expiry:'     + cert.expiry);
     sigContent.push('scopes:');
     sigContent = sigContent.concat(cert.scopes);
     var signature = crypto.createHmac('sha256', accessToken)

--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -20,7 +20,7 @@ var crypto        = require('crypto');
  * applies scope restrictions, certificate validation and returns a clone if
  * modified (otherwise it returns the original).
  */
-var limitClientWithExt = function(client, ext, expandScopes) {
+var parseExt = function(ext) {
   // Attempt to parse ext
   try {
     ext = JSON.parse(new Buffer(ext, 'base64').toString('utf-8'));
@@ -28,6 +28,20 @@ var limitClientWithExt = function(client, ext, expandScopes) {
   catch(err) {
     throw new Error("Failed to parse ext");
   }
+
+  return ext;
+}
+
+/**
+ * Limit the client scopes and possibly use temporary keys.
+ *
+ * Takes a client object on the form: `{clientId, accessToken, scopes}`,
+ * applies scope restrictions, certificate validation and returns a clone if
+ * modified (otherwise it returns the original).
+ */
+var limitClientWithExt = function(credentialName, issuingClientId, accessToken, scopes, ext, expandScopes) {
+  let issuingScopes = scopes;
+  let res = {scopes, accessToken};
 
   // Handle certificates
   if (ext.certificate) {
@@ -71,23 +85,48 @@ var limitClientWithExt = function(client, ext, expandScopes) {
       throw new Error("ext.certificate cannot last longer than 31 days!");
     }
 
-    // Check scope validity
+    // Check clientId validity
+    if (issuingClientId !== credentialName) {
+      if (!cert.name) {
+        throw new Error('ext.certificate.name must be set when ext.certificate.issuer is given');
+      }
+      if (typeof(cert.name) !== 'string') {
+        throw new Error('ext.certificate.name must be a string');
+      }
+      if (cert.name !== credentialName) {
+        throw new Error('ext.certificate.name must match the supplied clientId');
+      }
+      let createScope = 'auth:create-client:' + credentialName;
+      if (!utils.scopeMatch(issuingScopes, [[createScope]])) {
+        throw new Error("ext.certificate issuer `" + issuingClientId +
+                        "` doesn't have `" + createScope + "` for supplied clientId.");
+      }
+    } else {
+      if (cert.hasOwnProperty('name')) {
+        throw new Error('ext.certificate.name must only be used with ext.certificate.issuer');
+      }
+    }
 
     // Validate certificate scopes are subset of client
-    if (!utils.scopeMatch(client.scopes, [cert.scopes])) {
-      throw new Error("ext.certificate issuer `" + client.clientId +
+    if (!utils.scopeMatch(scopes, [cert.scopes])) {
+      throw new Error("ext.certificate issuer `" + issuingClientId +
                       "` doesn't have sufficient scopes");
     }
 
     // Generate certificate signature
-    var signature = crypto.createHmac('sha256', client.accessToken)
-      .update([
-        'version:'  + '1',
-        'seed:'     + cert.seed,
-        'start:'    + cert.start,
-        'expiry:'   + cert.expiry,
-        'scopes:',
-      ].concat(cert.scopes).join('\n'))
+    var sigContent = []
+    sigContent.push('version:'  + '1');
+    if (cert.name && cert.issuer) {
+      sigContent.push('name:'   + cert.name);
+      sigContent.push('issuer:' + cert.issuer);
+    }
+    sigContent.push('seed:'     + cert.seed);
+    sigContent.push('start:'    + cert.start);
+    sigContent.push('expiry:'   + cert.expiry);
+    sigContent.push('scopes:');
+    sigContent = sigContent.concat(cert.scopes);
+    var signature = crypto.createHmac('sha256', accessToken)
+      .update(sigContent.join('\n'))
       .digest('base64');
 
     // Validate signature
@@ -97,7 +136,7 @@ var limitClientWithExt = function(client, ext, expandScopes) {
     }
 
     // Regenerate temporary key
-    var temporaryKey = crypto.createHmac('sha256', client.accessToken)
+    var temporaryKey = crypto.createHmac('sha256', accessToken)
       .update(cert.seed)
       .digest('base64')
       .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
@@ -105,11 +144,8 @@ var limitClientWithExt = function(client, ext, expandScopes) {
       .replace(/=/g,  '');  // Drop '==' padding
 
     // Update scopes and accessToken
-    client = {
-      clientId:     client.clientId,
-      accessToken:  temporaryKey,
-      scopes:       expandScopes(cert.scopes),
-    };
+    res.accessToken = temporaryKey;
+    res.scopes = scopes = expandScopes(cert.scopes);
   }
 
   // Handle scope restriction with authorizedScopes
@@ -122,21 +158,16 @@ var limitClientWithExt = function(client, ext, expandScopes) {
       throw new Error("ext.authorizedScopes must be an array of valid scopes");
     }
 
-    // Validate authorizedScopes scopes are subset of client
-    if (!utils.scopeMatch(client.scopes, [ext.authorizedScopes])) {
+    // Validate authorizedScopes scopes are satisfied by client (or temp) scopes
+    if (!utils.scopeMatch(res.scopes, [ext.authorizedScopes])) {
       throw new Error("ext.authorizedScopes oversteps your scopes");
     }
 
-    // Update scopes on client object
-    client = {
-      clientId:     client.clientId,
-      accessToken:  client.accessToken,
-      scopes:       expandScopes(ext.authorizedScopes),
-    };
+    // Further limit scopes
+    res.scopes = scopes = expandScopes(ext.authorizedScopes);
   }
 
-  // Return modified client
-  return client;
+  return res;
 };
 
 
@@ -153,9 +184,8 @@ var limitClientWithExt = function(client, ext, expandScopes) {
  * The function returned takes an object:
  *     {method, resource, host, port, authorization}
  * And returns promise for an object on one of the forms:
- *     {status: 'auth-failed', message},
- *     {status: 'auth-success', scheme, scopes}, or,
- *     {status: 'auth-success', scheme, scopes, hash}
+ *     {status: 'auth-failed', message}, or
+ *     {status: 'auth-success', clientId, scheme, scopes}
  *
  * The `expandScopes` applies any rules that expands scopes, such as roles.
  * It is assumed that clients from `clientLoader` are returned with scopes
@@ -175,21 +205,44 @@ var createSignatureValidator = function(options) {
   assert(options.expandScopes instanceof Function,
          "options.expandScopes must be a function");
   var loadCredentials = function(clientId, ext, callback) {
-    Promise.resolve(options.clientLoader(clientId)).then(function(client) {
+    // We may have two clientIds here: the credentialName (the one the caller
+    // sent in the Hawk Authorization header) and the issuingClientId (the one
+    // that signed the temporary credentials).
+    let credentialName = clientId,
+        issuingClientId = clientId;
+
+    (async () => {
+      // extract ext.certificate.issuer, if present
       if (ext) {
-        // We check certificates and apply limitations to authorizedScopes here,
-        // if we've parsed ext incorrectly it could be a security issue, as
-        // scope elevation _might_ be possible. But it's a rather unlikely
-        // exploit... Besides we have plenty of obscurity to protect us here :)
-        client = limitClientWithExt(client, ext, options.expandScopes);
+        ext = parseExt(ext);
+        if (ext.certificate && ext.certificate.issuer) {
+          issuingClientId = ext.certificate.issuer;
+          if (typeof(issuingClientId) !== 'string') {
+            throw new Error('ext.certificate.issuer must be a string');
+          }
+          if (issuingClientId == credentialName) {
+            throw new Error('ext.certificate.issuer must differ from the supplied clientId');
+          }
+        }
       }
+
+      var accessToken, scopes;
+      ({clientId, accessToken, scopes} = await options.clientLoader(issuingClientId));
+
+      // apply restrictions based on the ext field
+      if (ext) {
+        ({scopes, accessToken} = limitClientWithExt(
+            credentialName, issuingClientId, accessToken,
+            scopes, ext, options.expandScopes));
+      }
+
       callback(null, {
-        clientToken:  client.clientId,
-        key:          client.accessToken,
-        algorithm:    'sha256',
-        scopes:       client.scopes
+        key:       accessToken,
+        algorithm: 'sha256',
+        clientId:  credentialName,
+        scopes:    scopes
       });
-    }).catch(callback);
+    })().catch(callback);
   };
   return function(req) {
     return new Promise(function(accept) {
@@ -213,7 +266,8 @@ var createSignatureValidator = function(options) {
           result = {
             status:   'auth-success',
             scheme:   'hawk',
-            scopes:   credentials.scopes
+            scopes:   credentials.scopes,
+            clientId: credentials.clientId
           };
           if (artifacts.hash) {
             result.hash = artifacts.hash;

--- a/schemas/authenticate-hawk-response.yml
+++ b/schemas/authenticate-hawk-response.yml
@@ -29,11 +29,20 @@ anyOf:
         type:                 string
         enum:
           - hawk
+      clientId:
+        description: |
+          The `clientId` that made this request.  This may be the `id` supplied in
+          the Authorization header, or in the case of a named temporary credential
+          may be embedded in the payload.  In any case, this clientId can be used
+          for logging, auditing, and identifying the credential but **must** not be
+          used for access control.  That's what scopes are for.
+        type:                 string
     additionalProperties:       false
     required:
       - status
       - scopes
       - scheme
+      - clientId
   - title:                    "Authentication Failed Response"
     type:                     object
     properties:

--- a/schemas/authenticate-hawk-response.yml
+++ b/schemas/authenticate-hawk-response.yml
@@ -29,13 +29,6 @@ anyOf:
         type:                 string
         enum:
           - hawk
-      hash:
-        description: |
-          Payload as extracted from `Authentication` header. This property is
-          only present if a hash is available. You are not required to validate
-          this hash, but if you do, please check `scheme` to ensure that it's
-          on a scheme you support.
-        type:                 string
     additionalProperties:       false
     required:
       - status


### PR DESCRIPTION
Credentials are {id, key, cert}.  A "simple" temporary credential has
the issing client as its `id`, scopes and expiry in the cert, all signed
to generate a new key.  "Named" temporary credentials further include a
name and an issuer in the certificate; the issuer is the clientId that
created the credential (and the corresponding accessToken is used in the
signature), while the name is the clientId that should be supplied as
`id`.  The result is that temporary credentials can have a meaningful
id that is useful for logging and for identifying the credentials.