### PR TITLE
Better explanatory message when authorized scopes are not satisfied.

### DIFF
--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -155,7 +155,9 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
 
     // Validate authorizedScopes scopes are satisfied by client (or temp) scopes
     if (!utils.scopeMatch(res.scopes, [ext.authorizedScopes])) {
-      throw new Error("ext.authorizedScopes oversteps your scopes");
+      throw new Error('Supplied credentials do not satisfy authorizedScopes; '
+        + `credentials have scopes [${res.scopes}]; `
+        + `authorizedScopes are [${[ext.authorizedScopes]}]`);
     }
 
     // Further limit scopes

--- a/test/signaturevalidator_test.js
+++ b/test/signaturevalidator_test.js
@@ -420,7 +420,9 @@ suite("signature validation", function() {
         authorizedScopes: ['scope1:*', 'scope2'],
       }
     }
-  }, failed('ext.authorizedScopes oversteps your scopes'));
+  }, failed('Supplied credentials do not satisfy authorizedScopes; '
+    + `credentials have scopes [${clients.unpriv.scopes}]; `
+    + `authorizedScopes are [scope1:*,scope2]`));
 
   test("invalid: authorizedScopes not an array", {
     authorization: {
@@ -527,7 +529,9 @@ suite("signature validation", function() {
         authorizedScopes: ['scope1', 'scope2'],
       },
     }
-  }), failed('ext.authorizedScopes oversteps your scopes'));
+  }), failed('Supplied credentials do not satisfy authorizedScopes; '
+    + `credentials have scopes [${clients.unpriv.scopes}]; `
+    + `authorizedScopes are [scope1,scope2]`));
 
   testWithTemp("invalid: temporary credentials with authorizedScopes, temp not satisfied", {
     id: 'unpriv',


### PR DESCRIPTION
When the clientId doesn't satisfies the authorized scopes, report the
client scopes and the authorized scopes in the error messsage.