### PR TITLE
Bug 1254733: include cert scopes in error message

### DIFF
--- a/auth/signaturevalidator.js
+++ b/auth/signaturevalidator.js
@@ -101,7 +101,9 @@ var limitClientWithExt = function(credentialName, issuingClientId, accessToken, 
     // Validate certificate scopes are subset of client
     if (!utils.scopeMatch(scopes, [cert.scopes])) {
       throw new Error("ext.certificate issuer `" + issuingClientId +
-                      "` doesn't have sufficient scopes");
+                      "` doesn't satisfiy all certificate scopes " +
+                      cert.scopes.join(', ') + ".  The temporary " +
+                      "credentials were not generated correctly.");
     }
 
     // Generate certificate signature

--- a/test/signaturevalidator_test.js
+++ b/test/signaturevalidator_test.js
@@ -503,7 +503,8 @@ suite("signature validation", function() {
       credentials: {id, key},
       ext: {certificate},
     }
-  }), failed("ext.certificate issuer `unpriv` doesn't have sufficient scopes"));
+  }), failed('ext.certificate issuer `unpriv` doesn\'t satisfiy all certificate ' +
+             'scopes godlike.  The temporary credentials were not generated correctly.'))
 
   testWithTemp("temporary credentials with authorizedScopes", {
     id: 'root',
@@ -544,7 +545,8 @@ suite("signature validation", function() {
         authorizedScopes: ['scope999'],
       },
     }
-  }), failed("ext.certificate issuer `unpriv` doesn't have sufficient scopes"));
+  }), failed('ext.certificate issuer `unpriv` doesn\'t satisfiy all certificate scopes ' +
+             'scope999.  The temporary credentials were not generated correctly.'))
 
   testWithTemp("named temporary credentials", {
     id: 'my-temp-cred',


### PR DESCRIPTION
When handling temporary credentials where cert.scopes are not satisfied
by the issuer's scopes, include the cert scopes in the error message to
help debugging.