### PR TITLE
Added sentry manager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: babel-node bin/server.js
+web:            babel-node bin/server.js server
+expireSentry:   babel-node bin/server.js expire-sentry

--- a/auth/sentry.js
+++ b/auth/sentry.js
@@ -1,0 +1,37 @@
+var api         = require('./v1');
+
+api.declare({
+  method:     'get',
+  route:      '/sentry/:project/dsn',
+  name:       'sentryDSN',
+  input:      undefined,
+  output:     'sentry-dsn-response.json#',
+  deferAuth:  true,
+  stability:  'stable',
+  scopes:     [['auth:sentry-dsn:<project>']],
+  title:      "Get DSN for Sentry Project",
+  description: [
+    "Get temporary DSN (access credentials) for a sentry project.",
+    "The credentials returned can be used with any Sentry client for up to",
+    "24 hours, after which the credentials will be automatically disabled.",
+    "",
+    "If the project doesn't exist it will be created, and assigned to the",
+    "initial team configured for this component. Contact a Sentry admin",
+    "to have the project transferred to a team you have access to if needed",
+  ].join('\n')
+}, async function(req, res) {
+  let project = req.params.project;
+
+  // Check scopes
+  if (!req.satisfies({project})) {
+    return;
+  }
+
+  let key = await this.sentryManager.projectDSN(project);
+
+  return res.reply({
+    project,
+    dsn: key.dsn,
+    expires: key.expires,
+  });
+});

--- a/auth/sentrymanager.js
+++ b/auth/sentrymanager.js
@@ -1,0 +1,137 @@
+let Sentry      = require('sentry-api').Client;
+let _           = require('lodash');
+let taskcluster = require('taskcluster-client');
+let debug       = require('debug')('app:sentry');
+let assert      = require('assert');
+
+let pattern = /^ managed \(expires-at:([0-9TZ:.-]+)\)$/;
+let parseKeys = (keys, prefix) => {
+  let results = [];
+  for (let k of keys) {
+    if (!_.startsWith(k.label, prefix)) {
+      continue;
+    }
+    let match = pattern.exec(k.label.substring(prefix.length));
+    if (!match) {
+      continue;
+    }
+    let expires = new Date(match[1]);
+    if (isNaN(expires)) {
+      continue;
+    }
+    results.push({
+      id:   k.id,
+      dsn:  k.dsn,
+      expires,
+    });
+  }
+  return _.sortBy(results, k => k.expires.getTime());
+};
+
+/** Wrapper for managing Sentry projects and expiring keys */
+class SentryManager {
+  /**
+   * Create SentryManager
+   *
+   * Options:
+   * {
+   *   organization:   '...',  // Sentry organization
+   *   hostname:       'app.getsentry.com',
+   *   apiKey:         '...',  // Organization API key
+   *   initialTeam:    '...',  // Initial team for new projects
+   *   keyPrefix:      '...',  // Prefix for keys
+   * }
+   */
+  constructor(options) {
+    assert(options);
+    assert(options.organization);
+    assert(options.hostname);
+    assert(options.apiKey);
+    assert(options.initialTeam);
+    assert(options.keyPrefix);
+    let url = 'https://' + options.apiKey + ':@' + options.hostname;
+    this._sentry = new Sentry(url);
+    this._organization = options.organization;
+    this._initialTeam = options.initialTeam;
+    this._projectDSNCache = {};
+    this._keyPrefix = options.keyPrefix;
+  }
+
+  /** Get DSN for a project, create project if needed, create key if needed */
+  async projectDSN(project) {
+    // First check if we have a recent enough version in the cache
+    let key = this._projectDSNCache[project];
+    if (key && key.expires > taskcluster.fromNow('25 hours')) {
+      return key;
+    }
+    delete this._projectDSNCache[project]; // clear cache
+
+    // If not we have to list the keys
+    let keys = null;
+    try {
+      keys = await this._sentry.projects.keys(this._organization, project);
+    } catch (err) {
+      debug(
+        'Failed to list keys for %s (will create project), err: %s, stack: %s',
+        project, err, err.stack
+      );
+      // Ignore error try to create the project, and list keys again.
+      await this._sentry.teams.createProject(
+        this._organization, this._initialTeam, {
+        name: project,
+        slug: project,
+      });
+      keys = await this._sentry.projects.keys(this._organization, project);
+    }
+
+    // Create new key if most recent key is too old
+    key = _.last(parseKeys(keys, this._keyPrefix)); // last is most recent
+    if (!key || key.expires < taskcluster.fromNow('25 hours')) {
+      // Create new key that expires in 48 hours
+      let expires = taskcluster.fromNow('48 hours');
+      let k = await this._sentry.projects.createKey(
+        this._organization, project, {
+        name: this._keyPrefix + ` managed (expires-at:${expires.toJSON()})`,
+      });
+      key = {
+        id:   k.id,
+        dsn:  k.dsn,
+        expires,
+      };
+    }
+
+    // Save to cache and return
+    return this._projectDSNCache[project] = key;
+  }
+
+  /** Remove old expired keys, returns number of keys deleted */
+  async purgeExpiredKeys(now = new Date()) {
+    // Get a list of all projects from this organization
+    let projects = await this._sentry.organizations.projects(this._organization);
+
+    let deleted = 0;
+    await Promise.all(projects.map(async (p) => {
+      // List all keys for each project
+      let keys = await this._sentry.projects.keys(this._organization, p.slug);
+
+      // Find expired keys
+      let expiredKeys = parseKeys(keys, this._keyPrefix).filter(key => {
+        return key.expires < now;
+      });
+
+      // Delete expired keys
+      await Promise.all(expiredKeys.map(key => {
+        debug('deleting key: %s from project: %s', key.id, p.slug);
+        deleted += 1;
+        return this._sentry.projects.deleteKey(
+          this._organization, p.slug, key.id
+        );
+      }));
+    }));
+
+    return deleted;
+  }
+}
+
+// Export SentryManager
+module.exports = SentryManager;

--- a/auth/v1.js
+++ b/auth/v1.js
@@ -57,10 +57,12 @@ var api = new API({
     table:      /^[A-Za-z][A-Za-z0-9]{2,62}$/,
 
     // Patterns for AWS
-    bucket:     /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/
+    bucket:     /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/,
                 // we could allow "." too, but S3 buckets with dot in the name
                 // doesn't work well with HTTPS and virtual-style hosting.
                 // Hence, we shouldn't encourage people to use them
+    // Project for sentry (and other per project resources)
+    project:    /^[a-zA-Z0-9_-]{1,22}$/,
   },
   context: [
     // Instances of data.Client and data.Role
@@ -79,7 +81,10 @@ var api = new API({
     'azureAccounts',
 
     // Signature validator
-    'signatureValidator'
+    'signatureValidator',
+
+    // SentryManager from sentrymanager.js
+    'sentryManager',
   ]
 });
 
@@ -730,7 +735,7 @@ api.declare({
 // on the API object exported from this file
 require('./aws');
 require('./azure');
-
+require('./sentry');
 
 /** Get all client information */
 api.declare({

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
-var base               = require('taskcluster-base');
-var data               = require('../auth/data');
-var v1                 = require('../auth/v1');
-var path               = require('path');
-var debug              = require('debug')('server');
-var Promise            = require('promise');
-var AWS                = require('aws-sdk-promise');
-var raven              = require('raven');
-var exchanges          = require('../auth/exchanges');
-var ScopeResolver      = require('../auth/scoperesolver');
-var signaturevalidator = require('../auth/signaturevalidator');
-var taskcluster        = require('taskcluster-client');
-var url                = require('url');
-var validate           = require('taskcluster-lib-validate');
-var loader             = require('taskcluster-lib-loader');
-var app                = require('taskcluster-lib-app');
+let base               = require('taskcluster-base');
+let data               = require('../auth/data');
+let v1                 = require('../auth/v1');
+let path               = require('path');
+let debug              = require('debug')('server');
+let Promise            = require('promise');
+let AWS                = require('aws-sdk-promise');
+let raven              = require('raven');
+let exchanges          = require('../auth/exchanges');
+let ScopeResolver      = require('../auth/scoperesolver');
+let signaturevalidator = require('../auth/signaturevalidator');
+let taskcluster        = require('taskcluster-client');
+let url                = require('url');
+let validate           = require('taskcluster-lib-validate');
+let loader             = require('taskcluster-lib-loader');
+let app                = require('taskcluster-lib-app');
+let SentryManager      = require('../auth/sentrymanager');
 
 // Create component loader
 let load = loader({
@@ -52,6 +53,11 @@ let load = loader({
     }
   },
 
+  sentryManager: {
+    requires: ['cfg'],
+    setup: ({cfg}) => new SentryManager(cfg.app.sentry),
+  },
+
   resolver: {
     requires: ['cfg'],
     setup: ({cfg}) => new ScopeResolver({
@@ -60,8 +66,8 @@ let load = loader({
   },
 
   Client: {
-    requires: ['cfg', 'drain', 'resolver'],
-    setup: ({cfg, drain, resolver}) =>
+    requires: ['cfg', 'drain', 'resolver', 'process'],
+    setup: ({cfg, drain, resolver, process}) =>
       data.Client.setup({
         table:        cfg.app.clientTableName,
         credentials:  cfg.azure || {},
@@ -69,21 +75,21 @@ let load = loader({
         cryptoKey:    cfg.app.tableCryptoKey,
         drain:        drain,
         component:    cfg.app.statsComponent,
-        process:      'server',
+        process,
         context:      {resolver}
       })
   },
 
   Role: {
-    requires: ['cfg', 'drain', 'resolver'],
-    setup: ({cfg, drain, resolver}) =>
+    requires: ['cfg', 'drain', 'resolver', 'process'],
+    setup: ({cfg, drain, resolver, process}) =>
       data.Role.setup({
         table:        cfg.app.rolesTableName,
         credentials:  cfg.azure || {},
         signingKey:   cfg.app.tableSigningKey,
         drain:        drain,
         component:    cfg.app.statsComponent,
-        process:      'server',
+        process,
         context:      {resolver}
       })
   },
@@ -97,7 +103,7 @@ let load = loader({
   },
 
   publisher: {
-    requires: ['cfg', 'validator', 'drain'],
+    requires: ['cfg', 'validator', 'drain', 'process'],
     setup: ({cfg, validator, drain, process}) =>
       exchanges.setup({
         credentials:      cfg.pulse,
@@ -108,13 +114,19 @@ let load = loader({
         aws:              cfg.aws,
         drain:            drain,
         component:        cfg.app.statsComponent,
-        process:          'server'
+        process,
       })
   },
 
   api: {
-    requires: ['cfg', 'Client', 'Role', 'validator', 'publisher', 'resolver', 'drain', 'raven'],
-    setup: async ({cfg, Client, Role, validator, publisher, resolver, drain, raven}) => {
+    requires: [
+      'cfg', 'Client', 'Role', 'validator', 'publisher', 'resolver',
+      'drain', 'raven', 'sentryManager'
+    ],
+    setup: async ({
+      cfg, Client, Role, validator, publisher, resolver, drain, raven,
+      sentryManager
+    }) => {
       // Set up the Azure tables
       await Role.ensureTable();
       await Client.ensureTable();
@@ -147,6 +159,7 @@ let load = loader({
           sts:                new AWS.STS(cfg.aws),
           azureAccounts:      cfg.app.azureAccounts,
           signatureValidator,
+          sentryManager,
         },
         validator,
         signatureValidator,
@@ -184,11 +197,24 @@ let load = loader({
       return serverApp.createServer();
     }
   },
-}, ['profile']);
 
-// If server.js is executed start the server
+  'expire-sentry': {
+    requires: ['cfg', 'sentryManager'],
+    setup: async ({cfg, sentryManager}) => {
+      let now = taskcluster.fromNow(cfg.app.sentryExpirationDelay);
+      if (isNaN(now)) {
+        console.log("FATAL: sentryExpirationDelay is not valid!");
+        process.exit(1);
+      }
+      await sentryManager.purgeExpiredKeys(now);
+    }
+  }
+}, ['profile', 'process']);
+
+// If this file is executed launch component from first argument
 if (!module.parent) {
-  load('server', {
+  load(process.argv[2], {
+    process: process.argv[2],
     profile: process.env.NODE_ENV,
   }).catch(err => {
     console.log(err.stack);

--- a/config.yml
+++ b/config.yml
@@ -32,6 +32,16 @@ defaults:
     # this value, and it's really only a best effort service.
     maxLastUsedDelay:         '- 6 hours'
 
+    # Sentry configuration
+    sentry:
+      organization:             taskcluster
+      hostname:                 app.getsentry.com
+      apiKey:                   !env SENRTY_API_KEY
+      initialTeam:              mozilla
+      keyPrefix:                taskcluster-auth
+
+    # Delay before expiring sentry keys, this should be negative!
+    sentryExpirationDelay:      '- 15 minutes'
   server:
     # Public URL from which the server can be accessed (used for persona)
     publicUrl:                https://auth.taskcluster.net
@@ -100,6 +110,12 @@ test:
     rootAccessToken:          PKqZk1pIRgKnSLNXC86rKwl5Rp5Ki4SsKlZGEu2_kGNQ
     # Special value for tests, as we don't want to wait forever
     maxLastUsedDelay:         '- 3 seconds'
+    sentry:
+      organization:             taskcluster
+      hostname:                 app.getsentry.com
+      apiKey:                   "no-key" # no-key skips tests
+      initialTeam:              mozilla
+      keyPrefix:                auth-test
   # Test bucket for STS credentials
   test:
     testBucket:               !env TEST_BUCKET

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "promise": "^7.0.4",
     "pulse-publisher": "^0.9.1",
     "raven": "^0.10.0",
+    "sentry-api": "jonasfj/node-sentry-api#create-project",
     "slugid": "^1.1.0",
     "superagent": "^1.1.0",
     "superagent-hawk": "0.0.4",

--- a/schemas/sentry-dsn-response.yml
+++ b/schemas/sentry-dsn-response.yml
@@ -1,0 +1,47 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:                      "Sentry DSN Response"
+description: |
+  Sentry DSN for submitting errors.
+type:                       object
+properites:
+  project:
+    type:           string
+    title:          Project
+    description: |
+      Project name that the DSN grants access to.
+  dsn:
+    type:           object
+    description: |
+      Access credentials and urls for the Sentry project.
+      Credentials will expire in 24-48 hours, you should refresh them within
+      24 hours.
+    properites:
+      secret:
+        type:       string
+        format:     uri
+        description: |
+          Access credential and URL for private error reports.
+          These credentials can be used for up-to 24 hours.
+          This is for use in serser-side applications and should **not** be
+          leaked.
+      public:
+        type:       string
+        format:     uri
+        description: |
+          Access credential and URL for public error reports.
+          These credentials can be used for up-to 24 hours.
+          This is for use in client-side applications only.
+    required:
+      - secret
+      - public
+  expires:
+    type:           string
+    format:         date-time
+    description: |
+      Expiration time for the credentials. The credentials should not be used
+      after this time. They might not be revoked immediately, but will be at
+      some arbitrary point after this date-time.
+required:
+  - project
+  - dsn
+  - expires

--- a/test/helper.js
+++ b/test/helper.js
@@ -36,6 +36,9 @@ var webServer = null, testServer;
 mocha.before(async () => {
   let overwrites = {};
   overwrites['profile'] = 'test';
+  overwrites['process'] = 'test';
+  helper.overwrites = overwrites;
+  helper.load = serverLoad;
 
   // if we don't have an azure account/key, use the inmemory version
   if (!cfg.azure || !cfg.azure.accountName) {

--- a/test/sentry_test.js
+++ b/test/sentry_test.js
@@ -1,0 +1,29 @@
+suite('sentry', function() {
+  let helper = require('./helper');
+  let taskcluster = require('taskcluster-client');
+  let assert = require('assert');
+
+  // Skip tests if we don't an have an API key
+  this.pending = (helper.cfg.app.sentry.apiKey === 'no-key');
+
+  test('sentryDSN', async () => {
+    await helper.auth.sentryDSN('playground');
+  });
+
+  test('purgeExpiredKeys', async () => {
+    let sentryManager = await helper.load('sentryManager', helper.overwrites);
+
+    // There shouldn't be any keys that'll expire from this
+    // As keys shouldn't have been any keys created 100 years ago
+    // This tests that we don't just purge all keys, but only the ones expired.
+    let farInThePast = taskcluster.fromNow('- 100 years');
+    let expired = await sentryManager.purgeExpiredKeys(farInThePast);
+    assert(expired === 0, "Didn't expect any keys to expire!");
+
+    // There should be keys expired, when we expire 7 days into the future
+    // we should at least see the key from the test case above be expired
+    let aWeekFromNow = taskcluster.fromNow('7 days');
+    expired = await sentryManager.purgeExpiredKeys(aWeekFromNow);
+    assert(expired > 0, "Expected at least one key to be expired");
+  });
+});


### PR DESCRIPTION
Sentry management...


Now we can grant access to sentry using taskcluster credentials.

Also we get: rotating temporary sentry credentials..  

Most notably, this makes it a lot easier to give an sentry access to all workers. As we won't have to burn the secret into the worker AMI... Or manually create a project per workerType and copy/paste credentials around.. 

@djmitche, cc'ing you in as you have bit of a stake in auth too... And this will add another proctype, that should run as scheduled job once a day or so...