### PR TITLE
Fixes for generic sentry issues.

### DIFF
--- a/auth/sentrymanager.js
+++ b/auth/sentrymanager.js
@@ -95,7 +95,7 @@ class SentryManager {
       });
       key = {
         id:   k.id,
-        dsn:  k.dsn,
+        dsn:  _.pick(k.dsn, ['secret', 'public']),
         expires,
       };
     }

--- a/config.yml
+++ b/config.yml
@@ -36,7 +36,7 @@ defaults:
     sentry:
       organization:             taskcluster
       hostname:                 app.getsentry.com
-      apiKey:                   !env SENRTY_API_KEY
+      apiKey:                   !env SENTRY_API_KEY
       initialTeam:              mozilla
       keyPrefix:                taskcluster-auth
 


### PR DESCRIPTION
There is a csp field in the dsn returned from the sentry api that we have to get rid of so that it matches the schema. I guess we could include it in the schema instead, but this seems like the more appropriate option.