### PR TITLE
Bug 1302753: log all successful authentications

### DIFF
--- a/src/signaturevalidator.js
+++ b/src/signaturevalidator.js
@@ -282,6 +282,12 @@ var createSignatureValidator = function(options) {
           if (artifacts.hash) {
             result.hash = artifacts.hash;
           }
+
+          // TODO: log this in a structured format when structured logging is
+          // available https://bugzilla.mozilla.org/show_bug.cgi?id=1307271
+          console.log(
+              `Authenticated ${result.clientId} for ${req.method.toUpperCase()} access to ` +
+              `https://${req.host}:${req.port}${req.resource}`)
         }
         return accept(result);
       };


### PR DESCRIPTION
This logs messages like
```
Authenticated mozilla-user/dmitchell@mozilla.com for PUT access to https://localhost:60551/v1/clients/nobody%2Fsds%3Aad_asd%2Fdf-sAdSfchsdfsdfs%2Fbb%2F1
```

An important thing to note here is, this will log all successful *authentications* regardless of whether the operation was *authorized* (which is determined by the service calling authenticateHawk).  So this doesn't completely solve the bug, but does give us a simple and effective way to determine whether and how a particular clientId was used during a particular timeframe.