### PR TITLE
Allow azure read-write access to grant read-only as well

### DIFF
--- a/src/azure.js
+++ b/src/azure.js
@@ -79,12 +79,10 @@ api.declare({
     });
   }
 
-  // Check that the client is authorized to access given account and table
-  if (!req.satisfies({
-    account:    account,
-    table:      tableName,
-    level:      level,
-  })) {
+  // We have a complicated scope situation for read-only since we want
+  // read-write to grant read-only permissions as well
+  if (!(level === 'read-only' && req.satisfies({account, table: tableName, level: 'read-write'}, true)) &&
+    !req.satisfies({account, table: tableName, level})) {
     return;
   }
 

--- a/test/azure_test.js
+++ b/test/azure_test.js
@@ -122,6 +122,26 @@ suite('azure table (sas)', function() {
     });
   });
 
+  test('azureTableSAS (allowed table rw -> ro)', function() {
+    // Restrict access a bit
+    var auth = new helper.Auth({
+      baseUrl:          helper.baseUrl,
+      credentials:      rootCredentials,
+      authorizedScopes: [
+        'auth:azure-table:read-write:' + helper.testaccount + '/allowedTable'
+      ]
+    });
+    return auth.azureTableSAS(
+      helper.testaccount,
+      'allowedTable',
+      'read-only'
+    ).then(function(result) {
+      assert(typeof(result.sas) === 'string', "Expected some form of string");
+      assert(new Date(result.expiry).getTime() > new Date().getTime(),
+             "Expected expiry to be in the future");
+    });
+  });
+
   test('azureTableSAS (too high permission)', function() {
     // Restrict access a bit
     var auth = new helper.Auth({


### PR DESCRIPTION
This is the simplest approach I could come up with that would grant access how we want and preserve nice error messages. Does it make sense to you?