### PR TITLE
Allow overriding buckets for redeploying

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,14 @@ defaults:
     statsum:
       secret:                   !env STATSUM_API_SECRET
       baseUrl:                  !env STATSUM_BASE_URL
+
+    # Overrides of s3 buckets for redeployability
+    # Leave unset if running inside Heroku
+    buckets:
+      docs:                     !env DOCS_BUCKET
+      schemas:                  !env SCHEMAS_BUCKET
+      references:               !env REFS_BUCKET
+
   server:
     # Public URL from which the server can be accessed (used for persona)
     publicUrl:                https://auth.taskcluster.net

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,8 @@ let load = Loader({
     requires: ['cfg'],
     setup: ({cfg}) => Validate({
       prefix:  'auth/v1/',
-      aws:      cfg.aws
+      aws:      cfg.aws,
+      bucket:   cfg.app.buckets.schemas,
     })
   },
 
@@ -104,6 +105,7 @@ let load = Loader({
       aws: cfg.aws,
       tier: 'platform',
       schemas: validator.schemas,
+      bucket: cfg.app.buckets.docs,
       project: 'auth',
       references: [
         {
@@ -131,6 +133,7 @@ let load = Loader({
         referencePrefix:  'auth/v1/exchanges.json',
         publish:          cfg.app.publishMetaData,
         aws:              cfg.aws,
+        referenceBucket:  cfg.app.buckets.references,
         monitor:          monitor.prefix('publisher'),
       })
   },
@@ -184,6 +187,7 @@ let load = Loader({
         baseUrl:            cfg.server.publicUrl + '/v1',
         referencePrefix:    'auth/v1/api.json',
         aws:                cfg.aws,
+        referenceBucket:    cfg.app.buckets.references,
         monitor:            monitor.prefix('api'),
       });
     }


### PR DESCRIPTION
I believe this will work in our current Heroku environment as well, since these will be undefined and the defaults will take over. This is designed to work with https://github.com/imbstack/taskcluster-standalone and it seems to work correctly there. I get docs/schemas/references uploaded to my personal buckets and the service runs happily in Kubernetes.

If there's a better way to go about this, let's do that instead. Also very open to picking different names for these fields.