### PR TITLE
Use azure-entities 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "assume": "^1.3.1",
     "aws-sdk": "^2.2.0",
     "aws-sdk-promise": "^0.0.2",
-    "azure-entities": "^1.2.0",
+    "azure-entities": "2.0.0",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
     "babel-runtime": "^6.6.1",

--- a/test/helper.js
+++ b/test/helper.js
@@ -51,15 +51,15 @@ mocha.before(async () => {
     helper.Client = overwrites['Client'] = data.Client.setup({
       table: 'Client',
       account: 'inMemory',
+      credentials: null,
       cryptoKey,
       signingKey,
-      context: {resolver: overwrites.resolver},
     });
     helper.Role = overwrites['Role'] = data.Role.setup({
       table: 'Role',
       account: 'inMemory',
+      credentials: null,
       signingKey,
-      context: {resolver: overwrites.resolver},
     });
   } else {
     helper.Client = overwrites['Client'] = await serverLoad('Client', overwrites);

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,15 +165,15 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-azure-entities@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/azure-entities/-/azure-entities-1.2.1.tgz#86f4fd6e253ba63f6386a888716f783c9d6a6147"
+azure-entities@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/azure-entities/-/azure-entities-2.0.0.tgz#82a3beab40a0041f4ae5778b2dd03c3e0c6809f9"
   dependencies:
     ajv "^4.11.2"
     babel-runtime "^6.22.0"
     buffertools "^2.1.3"
     debug "^2.2.0"
-    fast-azure-storage "^0.3.7"
+    fast-azure-storage "^1.0.2"
     json-stable-stringify "^1.0.0"
     lodash "^4.17.4"
     promise "^7.0.4"
@@ -1127,9 +1127,9 @@ eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
-fast-azure-storage@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-0.3.7.tgz#638b11ab074d5774cfd6fe8c628f0a419ef2874d"
+fast-azure-storage@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-1.0.0.tgz#09280bab54aa921fd878c7808c97cb0b7d92dbe8"
   dependencies:
     debug "^2.2.0"
     pixl-xml "^1.0.10"
@@ -1137,9 +1137,9 @@ fast-azure-storage@^0.3.7:
   optionalDependencies:
     libxmljs "^0.18.0"
 
-fast-azure-storage@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-1.0.0.tgz#09280bab54aa921fd878c7808c97cb0b7d92dbe8"
+fast-azure-storage@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-1.0.2.tgz#00d46a790f69d69bd3ea131ee95b5df7c5ac0e3b"
   dependencies:
     debug "^2.2.0"
     pixl-xml "^1.0.10"
@@ -2394,11 +2394,11 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.7:
+stack-trace@0.0.7, stack-trace@0.0.x:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.7.tgz#c72e089744fc3659f508cdce3621af5634ec0fff"
 
-stack-trace@0.0.9, stack-trace@0.0.x:
+stack-trace@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
 


### PR DESCRIPTION
This is the only repo I could find that would not work with the 2.0.0 version of azure-entities which enforced credentials being passed. This upgrades the version of the library and updates the code to work with it. It also removes some old broken bits that broke tests when no azure creds are specified.