### PR TITLE
Move sentry to mozilla hosted instance

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -34,10 +34,10 @@ defaults:
 
     # Sentry configuration
     sentry:
-      organization:             taskcluster
-      hostname:                 app.getsentry.com
+      organization:             operations
+      hostname:                 sentry.prod.mozaws.net
       apiKey:                   !env SENTRY_API_KEY
-      initialTeam:              mozilla
+      initialTeam:              taskcluster
       keyPrefix:                taskcluster-auth
 
     # Delay before expiring sentry keys, this should be negative!
@@ -120,10 +120,7 @@ test:
     # Special value for tests, as we don't want to wait forever
     maxLastUsedDelay:         '- 3 seconds'
     sentry:
-      organization:             taskcluster
-      hostname:                 app.getsentry.com
       apiKey:                   "no-key" # no-key skips tests
-      initialTeam:              mozilla
       keyPrefix:                auth-test
     statsum:
       secret:                   'secret'


### PR DESCRIPTION
To roll this out I would deploy this code and then swap the api key in heroku config for the new one we've been provided for the mozilla instance. There will be a brief period where tc-lib-monitor won't function correctly, but I think that's acceptable.

https://bugzilla.mozilla.org/show_bug.cgi?id=1361169