### PR TITLE
Faster resolver

### DIFF
--- a/src/scoperesolver.js
+++ b/src/scoperesolver.js
@@ -368,18 +368,14 @@ class ScopeResolver extends events.EventEmitter {
         // execute the DFA and expand any parameterizations in the result, then add
         // the newly expanded scopes to the list of scopes to expand (recursively)
         const trailingStar = scope.endsWith('*');
-        executeTrie(dfa, scope).forEach((expansion, k) => {
-          if (!expansion) {
-            return;
-          }
-
+        executeTrie(dfa, scope, (scopes, offset) => {
           // Get the replacement slice for any parameterization. If this is empty and the
           // scope ended with `*`, consider that `*` to have been extended into the
           // replacement.
-          const slice = scope.slice(k) || (trailingStar ? '*' : '');
+          const slice = scope.slice(offset) || (trailingStar ? '*' : '');
           const parameter_regexp = trailingStar ? PARAMETER_TO_END : PARAMETER_G;
 
-          expansion.map(s => s.replace(parameter_regexp, slice)).forEach(s => {
+          scopes.map(s => s.replace(parameter_regexp, slice)).forEach(s => {
             // mark this scope as seen, and if it is novel and expandable, add it
             // to the queue for expansion
             if (see(s) && ASSUME_PREFIX.test(s)) {

--- a/src/trie.js
+++ b/src/trie.js
@@ -85,23 +85,18 @@ exports.generateTrie = (rules) => {
 };
 
 /**
- * Executes the trie for a single input, returning an array of scopes
- * such that the scopes at result[k] were matched with input.slice(k)
- * not yet consumed (and thus available for parameterization).
- *
- * Note that the input is considered to be followed by an 'end' character,
- * so it may be that result.length > input.length; on the other hand, if
- * the trie completes matching before the input is consumed, result.length
- * can be smaller.
+ * Executes the trie for a single input, invoking cb(scopes, offset) whenever
+ * scopes are matched wuth input.slice(offset) unconsumed, and thus relevant
+ * for parameterization.
  */
-exports.executeTrie = (trie, input) => {
+exports.executeTrie = (trie, input, cb) => {
   let state = trie;
-  let result = [];
   let k = 0;
 
   while (state) {
-    result.push(state.scopes);
+    if (state.scopes) {
+      cb(state.scopes, k);
+    }
     state = state[input[k++] || 'end'];
   }
-  return result;
 };

--- a/test/scoperesolver_test.js
+++ b/test/scoperesolver_test.js
@@ -338,31 +338,52 @@ suite('scoperesolver', () => {
     const scopeResolver = new ScopeResolver();
     const makeResolver = roles => scopeResolver.buildResolver(roles);
     const shouldMeasure = process.env.MEASURE_PERFORMANCE;
-    const measureN = 50;
-    const measureSkip = 5; // initial runs to skip (allows JIT warmup)
     const timings = [];
 
     const testResolver = (title, {roles, scopes, expected}) => {
       test(title, function() {
-        let timing, time;
+        let time;
         if (shouldMeasure) {
           // this could take a while..
           this.slow(3600000);
           this.timeout(0);
 
-          timing = {title};
+          let timing = {title};
           timings.push(timing);
+
+          const MIN_ITERATIONS = 5; // during warmup only
+          const PREHEAT_TIME = 500 * 1000000 // ns
+          const TIMEING_TIME = 3 * 1000000000 // ns
           time = (step, fn) => {
             let result;
-            timing[step] = [];
-            for (let i = 0; i < measureN; i++) {
-              const start = process.hrtime();
-              result = fn();
-              const took = process.hrtime(start);
-              timing[step].push(took[0] * 1000000000 + took[1]);
+            let mean;
+            let count = 0;
+            // initial runs to skip (allows JIT warmup)
+            // we also use this to estimate how many iterations we need to run
+            // inorder to do timing for TIMEING_TIME time.
+            const preheat = process.hrtime();
+            while(true) {
+              for (let i = 0; i < MIN_ITERATIONS; i++) {
+                result = fn();
+              }
+              count += 1;
+              const diff = process.hrtime(preheat);
+              if (diff[0] * 1000000000 + diff[1] > PREHEAT_TIME) {
+                mean = (diff[0] * 1000000000 + diff[1]) / (MIN_ITERATIONS * count);
+                break;
+              }
             }
-            timing[step].splice(0, measureSkip);
-            let mean = _.reduce(timing[step], (a, b) => a + b) / timing[step].length;
+            // Estimate iterations to measure and run them
+            let iterations = Math.ceil(TIMEING_TIME / mean);
+            const start = process.hrtime();
+            for (let i = 0; i < iterations; i++) {
+              result = fn();
+            }
+            const diff = process.hrtime(start);
+            mean = (diff[0] * 1000000000 + diff[1]) / iterations;
+
+            timing[step] = mean;
+
             let unit = 'ns';
             if (mean > 1000) {
               mean /= 1000;

--- a/test/scoperesolver_test.js
+++ b/test/scoperesolver_test.js
@@ -352,8 +352,8 @@ suite('scoperesolver', () => {
           timings.push(timing);
 
           const MIN_ITERATIONS = 5; // during warmup only
-          const PREHEAT_TIME = 500 * 1000000 // ns
-          const TIMEING_TIME = 3 * 1000000000 // ns
+          const PREHEAT_TIME = 500 * 1000000; // ns
+          const TIMEING_TIME = 3 * 1000000000; // ns
           time = (step, fn) => {
             let result;
             let mean;
@@ -362,7 +362,7 @@ suite('scoperesolver', () => {
             // we also use this to estimate how many iterations we need to run
             // inorder to do timing for TIMEING_TIME time.
             const preheat = process.hrtime();
-            while(true) {
+            while (true) {
               for (let i = 0; i < MIN_ITERATIONS; i++) {
                 result = fn();
               }


### PR DESCRIPTION
The first commit just touches timing logic... I'm not sure it got much more stable :)

the second touches `executeTrie`, I didn't see any notable effect... but I think this change is uncontroversial.