### PR TITLE
Use POST for expandScopes

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -793,6 +793,26 @@ api.declare({
 api.declare({
   method:     'get',
   route:      '/scopes/expand',
+  name:       'expandScopesGet',
+  input:      'scopeset.json#',
+  output:     'scopeset.json#',
+  stability:  'deprecated',
+  title:      'Expand Scopes',
+  description: [
+    'Return an expanded copy of the given scopeset, with scopes implied by any',
+    'roles included.',
+    '',
+    'This call uses the GET method with an HTTP body.  It remains only for',
+    'backward compatibility.',
+  ].join('\n'),
+}, async function(req, res) {
+  let input = req.body;
+  return res.reply({scopes: this.resolver.resolve(input.scopes)});
+});
+
+api.declare({
+  method:     'post',
+  route:      '/scopes/expand',
   name:       'expandScopes',
   input:      'scopeset.json#',
   output:     'scopeset.json#',


### PR DESCRIPTION
Docker-worker calls the existing (GET-based) expandScopes, so that
remains in place as expandScopesGet, but marked deprecated.  When
docker-worker is upgraded to not use the old method, or is itself
deprecated, we can remove expandScopesOld.

Thanks to @Biboswan for finding this issue in https://github.com/taskcluster/taskcluster-tools/issues/278.