### PR TITLE
Add bang symbol to the client ID schema

### DIFF
--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -5,7 +5,7 @@ access-token-pattern:     "^[a-zA-Z0-9_-]{22,66}$"
 # Printable ascii string for roleId
 roleId: "^[\\x20-\\x7e]+$"
 
-clientId: "^[A-Za-z0-9%@/:.+|_-]+$"
+clientId: "^[A-Za-z0-9!@/:.+|_-]+$"
 
 # Slugid pattern, for when-ever that is useful
 slugid-pattern: "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -5,7 +5,7 @@ access-token-pattern:     "^[a-zA-Z0-9_-]{22,66}$"
 # Printable ascii string for roleId
 roleId: "^[\\x20-\\x7e]+$"
 
-clientId: "^[A-Za-z0-9@/:.+|_-]+$"
+clientId: "^[A-Za-z0-9%@/:.+|_-]+$"
 
 # Slugid pattern, for when-ever that is useful
 slugid-pattern: "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"


### PR DESCRIPTION
Auth0 doesn't provide a nice user ID for GitHub logins. For GitHub, we
receive IDs of the form `github|12334`. For better user IDs, we append the
GitHub nickname to the ID (e.g, `github|1234/helfi92`). Encoding the
latter gives `github%7C1234%2Fhelfi92`. To be able to use this,` %` needs to
be included in the Client ID schema.

See also:
https://github.com/taskcluster/taskcluster-login/pull/71#issuecomment-364785926
https://github.com/taskcluster/taskcluster-login/pull/71#discussion_r167710957