### PR TITLE
WIP to make test run without pulse credentials

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -151,8 +151,8 @@ let load = Loader({
 
   connection: {
     requires: ['cfg'],
-    setup: async ({ cfg }) => {
-      return new taskcluster.PulseConnection(cfg.pulse)
+    setup: async ({cfg}) => {
+      return new taskcluster.PulseConnection(cfg.pulse);
     },
   },
 
@@ -162,7 +162,7 @@ let load = Loader({
       'sentryManager', 'monitor', 'connection',
     ],
     setup: async ({
-      cfg, Client, Roles, validator, publisher, resolver, sentryManager, monitor, connection
+      cfg, Client, Roles, validator, publisher, resolver, sentryManager, monitor, connection,
     }) => {
       // Set up the Azure tables
       await Client.ensureTable();

--- a/src/main.js
+++ b/src/main.js
@@ -149,13 +149,20 @@ let load = Loader({
       }),
   },
 
+  connection: {
+    requires: ['cfg'],
+    setup: async ({ cfg }) => {
+      return new taskcluster.PulseConnection(cfg.pulse)
+    },
+  },
+
   api: {
     requires: [
       'cfg', 'Client', 'Roles', 'validator', 'publisher', 'resolver',
-      'sentryManager', 'monitor',
+      'sentryManager', 'monitor', 'connection',
     ],
     setup: async ({
-      cfg, Client, Roles, validator, publisher, resolver, sentryManager, monitor,
+      cfg, Client, Roles, validator, publisher, resolver, sentryManager, monitor, connection
     }) => {
       // Set up the Azure tables
       await Client.ensureTable();
@@ -170,7 +177,7 @@ let load = Loader({
           credentials:      cfg.pulse,
           exchangePrefix:   cfg.app.exchangePrefix,
         }),
-        connection: new taskcluster.PulseConnection(cfg.pulse),
+        connection: connection,
       });
 
       let signatureValidator = signaturevalidator.createSignatureValidator({

--- a/src/v1.js
+++ b/src/v1.js
@@ -20,6 +20,7 @@ const roleToJson = (role, context) => _.defaults(
 /** API end-point for version v1/ */
 var api = new API({
   title:      'Authentication API',
+  name:       'auth',
   description: [
     'Authentication related API end-points for Taskcluster and related',
     'services. These API end-points are of interest if you wish to:',

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -10,9 +10,9 @@ suite('api (client)', function() {
   var taskcluster = require('taskcluster-client');
 
   if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
+    // setup(function() {
+    //   this.skip();
+    // });
   } else {
     const cleanup = async () => {
       // Delete all non-static clients and roles

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -11,12 +11,11 @@ suite('api (client)', function() {
 
   const cleanup = async () => {
     // Delete all clients and roles
-    await helper.Client.scan({}, {handler: c => c.clientId === 'root' ? null : c.remove()});
+    await helper.Client.scan({}, {handler: c => c.clientId === 'static/taskcluster/root' ? null : c.remove()});
     await helper.Roles.modify((roles) => roles.splice(0));
   };
   setup(cleanup);
   teardown(cleanup);
-
 
   test('ping', async () => {
     await helper.auth.ping();

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -37,14 +37,14 @@ suite('api (client)', function() {
   });
   const CLIENT_ID = 'nobody/sds:ad_asd/df-sAdSfchsdfsdfs';
   test('auth.deleteClient (non-existent)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.clientDeleted({
+    await helper.authEvents.clientDeleted({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     await helper.auth.deleteClient(CLIENT_ID);
     await helper.auth.deleteClient(CLIENT_ID);
 
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientDeleted', clientId: CLIENT_ID}]);
   });
 
   test('auth.deleteClient (invalid root credentials)', async () => {
@@ -70,9 +70,10 @@ suite('api (client)', function() {
   });
 
   test('auth.createClient (no scopes)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.clientCreated({
+
+    await helper.authEvents.clientCreated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     var expires = taskcluster.fromNow('1 hour');
     var description = 'Test client...';
@@ -91,7 +92,7 @@ suite('api (client)', function() {
     assume(client2).has.not.own('accessToken');
     assume(client2.expandedScopes).to.deeply.equal([]);
 
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientCreated', clientId: CLIENT_ID}]);
     await helper.auth.deleteClient(CLIENT_ID);
   });
 
@@ -132,9 +133,9 @@ suite('api (client)', function() {
   });
 
   test('auth.createClient (with scopes)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.clientCreated({
+    await helper.authEvents.clientCreated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     var expires = taskcluster.fromNow('1 hour');
     var description = 'Test client...';
@@ -162,13 +163,13 @@ suite('api (client)', function() {
     assume(client2.scopes).not.contains('assume:client-id:' + CLIENT_ID);
     assume(client2.expandedScopes).not.contains('assume:client-id:' + CLIENT_ID);
 
-    await helper.events.waitFor('e1');
+  assert.deepEqual(helper.publisher.calls, [{method: 'clientCreated', clientId: CLIENT_ID}]);
   });
 
   const createTestClient = async () => {
-    await helper.events.listenFor('created', helper.authEvents.clientCreated({
+    await helper.authEvents.clientCreated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     var expires = taskcluster.fromNow('1 hour');
     var description = 'Test client...';
@@ -177,21 +178,21 @@ suite('api (client)', function() {
       expires, description, scopes,
     });
 
-    await helper.events.waitFor('created');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientDeleted', clientId: CLIENT_ID},
+      {method: 'clientDeleted', clientId: CLIENT_ID}]);
   };
 
   test('auth.resetAccessToken', async () => {
-    await createTestClient();
 
-    await helper.events.listenFor('e1', helper.authEvents.clientUpdated({
+    helper.authEvents.clientUpdated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     let client = await helper.auth.resetAccessToken(CLIENT_ID);
     assume(new Date(client.lastRotated).getTime())
       .is.greaterThan(new Date(client.lastModified).getTime());
     assume(client.accessToken).is.a('string');
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientUpdated', clientId: CLIENT_ID}]);
 
     let client2 = await helper.auth.client(CLIENT_ID);
     assume(client2.lastRotated).equals(client.lastRotated);
@@ -199,7 +200,6 @@ suite('api (client)', function() {
   });
 
   test('use client', async () => {
-    await createTestClient();
 
     // Fetch client
     let r1 = await helper.auth.client(CLIENT_ID);
@@ -239,11 +239,10 @@ suite('api (client)', function() {
   });
 
   test('auth.updateClient (no scope changes)', async () => {
-    await createTestClient();
 
-    await helper.events.listenFor('e1', helper.authEvents.clientUpdated({
+    helper.authEvents.clientUpdated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     var expires = new Date();
     let description = 'Different test description...';
@@ -259,7 +258,7 @@ suite('api (client)', function() {
     assume(client.scopes).contains('myapi:*');
     assume(client.expandedScopes).contains('scope1');
     assume(client.expandedScopes).contains('myapi:*');
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientUpdated', clientId: CLIENT_ID}]);
 
     let client2 = await helper.auth.client(CLIENT_ID);
     assume(client2.lastModified).equals(client.lastModified);
@@ -271,11 +270,10 @@ suite('api (client)', function() {
   });
 
   test('auth.updateClient (with scope changes)', async () => {
-    await createTestClient();
 
-    await helper.events.listenFor('e1', helper.authEvents.clientUpdated({
+    helper.authEvents.clientUpdated({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     var expires = new Date();
     let description = 'Third test description...';
@@ -296,7 +294,7 @@ suite('api (client)', function() {
     assume(client.expandedScopes).contains('scope2');
     assume(client.expandedScopes).contains('scope3');
     assume(client.expandedScopes).not.contains('myapi:*');
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientUpdated', clientId: CLIENT_ID}]);
 
     let client2 = await helper.auth.client(CLIENT_ID);
     assume(client2.lastModified).equals(client.lastModified);
@@ -310,7 +308,6 @@ suite('api (client)', function() {
   });
 
   test('auth.disableClient / enableClient', async () => {
-    await createTestClient();
 
     let client = await helper.auth.disableClient(CLIENT_ID);
     assume(client.disabled).equals(true);
@@ -328,16 +325,15 @@ suite('api (client)', function() {
   });
 
   test('auth.deleteClient', async () => {
-    await createTestClient();
 
-    await helper.events.listenFor('e1', helper.authEvents.clientDeleted({
+    helper.authEvents.clientDeleted({
       clientId:  CLIENT_ID,
-    }));
+    });
 
     await helper.auth.deleteClient(CLIENT_ID);
     await helper.auth.deleteClient(CLIENT_ID);
 
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'clientDeleted', clientId: CLIENT_ID}]);
 
     await helper.auth.client(CLIENT_ID).then(() => {
       assert(false, 'Expected an error');
@@ -364,12 +360,12 @@ suite('api (client)', function() {
   });
 
   test('auth.expandScopes with expanding scopes', async () => {
-    await helper.events.listenFor('role-a', helper.authEvents.roleCreated({
-      roleId:  'myrole:a',
-    }));
-    await helper.events.listenFor('role-b', helper.authEvents.roleCreated({
-      roleId:  'myrole:b',
-    }));
+    helper.authEvents.roleCreated({
+      roleId:  'myrole:a'
+    });
+    helper.authEvents.roleCreated({
+      roleId:  'myrole:b'
+    });
 
     await helper.auth.createRole('myrole:a', {
       description: 'test role',
@@ -379,8 +375,8 @@ suite('api (client)', function() {
       description: 'test role',
       scopes: ['assume:myrole:a', 'myapi:b:a'],
     });
-    await helper.events.waitFor('role-a');
-    await helper.events.waitFor('role-b');
+
+    assert.deepEqual(helper.publisher.calls, [{method: 'roleCreated', roleId: 'myrole:a'},{method: 'roleCreated', roleId: 'myrole:b'}]);
 
     assumeScopesetsEqual(await helper.auth.expandScopes({scopes: [
       'assume:myrole:b',

--- a/test/helper.js
+++ b/test/helper.js
@@ -17,6 +17,7 @@ var containers  = require('../src/containers');
 var uuid        = require('uuid');
 var Exchanges = require('pulse-publisher');
 
+process.env.pulse = {fake: true};
 // Load configuration
 var cfg = Config({profile: 'test'});
 
@@ -42,7 +43,9 @@ helper.hasAzureCredentials = function() {
 // Configure PulseTestReceiver
 if (cfg.pulse.password) {
   helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);
-};
+} else {
+  helper.events = new testing.PulseTestReceiver({fake:true}, mocha);
+}
 
 // fake "Roles" container
 class FakeRoles {
@@ -126,7 +129,6 @@ mocha.before(async () => {
   if (!helper.hasPulseCredentials()) {
     webServer = null;
     helper.baseUrl = 'http://localhost:8080/v1';
-
   } else {
     webServer = await serverLoad('server', overwrites);
     webServer.setTimeout(3500); // >3s because Azure can be sloooow
@@ -167,7 +169,7 @@ mocha.before(async () => {
 
   var exchangeReference = exchanges.reference({
     exchangePrefix:   cfg.app.exchangePrefix,
-    credentials:      cfg.pulse,
+    credentials:      {fake: true},
   });
   helper.AuthEvents = taskcluster.createClient(exchangeReference);
   helper.authEvents = new helper.AuthEvents();

--- a/test/helper.js
+++ b/test/helper.js
@@ -145,8 +145,8 @@ mocha.before(async () => {
     helper.auth = new helper.Auth({
       baseUrl:          helper.baseUrl,
       credentials: {
-        clientId:       'root',
-        accessToken:    cfg.app.rootAccessToken,
+        clientId:       'static/taskcluster/root',
+        accessToken:    helper.rootAccessToken,
       },
       authorizedScopes: scopes.length > 0 ? scopes : undefined,
     });
@@ -162,7 +162,7 @@ mocha.before(async () => {
     client:     testClient,
   } = await testserver({
     authBaseUrl: helper.baseUrl,
-    rootAccessToken: cfg.app.rootAccessToken,
+    rootAccessToken: helper.rootAccessToken,
   });
 
   testServer = testServer_;

--- a/test/helper.js
+++ b/test/helper.js
@@ -17,10 +17,8 @@ var containers  = require('../src/containers');
 var uuid        = require('uuid');
 var Exchanges = require('pulse-publisher');
 
-process.env.AZURE_ACCOUNTS = {taskclusterdev: "hello"}
 // Load configuration
 var cfg = Config({profile: 'test'});
-
 
 // Create subject to be tested by test
 var helper = module.exports = {};
@@ -40,10 +38,6 @@ helper.hasPulseCredentials = function() {
 helper.hasAzureCredentials = function() {
   return cfg.app.hasOwnProperty('azureAccounts') && cfg.app.azureAccounts;
 };
-// Configure PulseTestReceiver
-if (cfg.pulse.password) {
-  helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);
-}
 
 // fake "Roles" container
 class FakeRoles {
@@ -66,7 +60,9 @@ class FakePublisher {
   }
 
   async clientCreated({clientId}) {
-    this.calls.push({method:'clientCreated', clientId});
+    if (this.calls.filter(call => call.method == 'clientCreated' && call.clientId == clientId).length  == 0) {
+      this.calls.push({method: 'clientCreated', clientId});
+    }
     return Promise.resolve();
   }
 
@@ -76,7 +72,7 @@ class FakePublisher {
   }
 
   async clientDeleted({clientId}) {
-    if (this.calls.filter(call => call.method == 'clientDeleted' && call.clientId == clientId).length  == 0){
+    if (this.calls.filter(call => call.method == 'clientDeleted' && call.clientId == clientId).length  == 0) {
       this.calls.push({method:'clientDeleted', clientId});
     }
     return Promise.resolve();
@@ -88,12 +84,17 @@ class FakePublisher {
   }
 
   async roleCreated({roleId}) {
-    this.calls.push({method:'roleCreated', roleId});
+    if (this.calls.filter(call => call.method == 'roleCreated' && call.roleId == roleId).length  == 0) {
+      this.calls.push({method:'roleCreated', roleId});
+    }
+
     return Promise.resolve();
   }
 
   async roleDeleted({roleId}) {
-    this.calls.push({method:'roleDeleted', roleId});
+    if (this.calls.filter(call => call.method == 'roleDeleted' && call.roleId == roleId).length  == 0) {
+      this.calls.push({method:'roleDeleted', roleId});
+    }
     return Promise.resolve();
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -66,32 +66,34 @@ class FakePublisher {
   }
 
   async clientCreated({clientId}) {
-    this.calls.push({method:'clientCreated'}, clientId);
+    this.calls.push({method:'clientCreated', clientId});
     return Promise.resolve();
   }
 
   async clientUpdated({clientId}) {
-    this.calls.push({method:'clientUpdated'}, clientId);
+    this.calls.push({method:'clientUpdated', clientId});
     return Promise.resolve();
   }
 
   async clientDeleted({clientId}) {
-    this.calls.push({method:'clientUpdated'}, clientId);
+    if (this.calls.filter(call => call.method == 'clientDeleted' && call.clientId == clientId).length  == 0){
+      this.calls.push({method:'clientDeleted', clientId});
+    }
     return Promise.resolve();
   }
 
-  async roleUpdated({clientId}) {
-    this.calls.push({method:'roleUpdated'}, clientId);
+  async roleUpdated({roleId}) {
+    this.calls.push({method:'roleUpdated', roleId});
     return Promise.resolve();
   }
 
-  async roleCreated(clientId) {
-    this.calls.push({method:'roleCreated'}, clientId);
+  async roleCreated({roleId}) {
+    this.calls.push({method:'roleCreated', roleId});
     return Promise.resolve();
   }
 
-  async roleDeleted(clientId) {
-    this.calls.push({method:'roleDeleted'}, clientId);
+  async roleDeleted({roleId}) {
+    this.calls.push({method:'roleDeleted', roleId});
     return Promise.resolve();
   }
 }
@@ -125,7 +127,7 @@ mocha.before(async () => {
     await helper.Roles.setup();
   }
 
-  overwrites.publisher = new FakePublisher();
+  overwrites.publisher = helper.publisher = new FakePublisher();
 
   overwrites.resolver = helper.resolver =
     await serverLoad('resolver', overwrites);
@@ -178,9 +180,8 @@ mocha.before(async () => {
 
 mocha.beforeEach(() => {
   // Setup client with all scopes
-  if (helper.hasPulseCredentials()) {
-    helper.scopes();
-  }
+  helper.scopes();
+  helper.publisher.calls = [];
 });
 
 // Cleanup after tests
@@ -201,9 +202,6 @@ mocha.after(async () => {
       // before the tests are complete, so we "leak" containers despite this effort to
       // clean them up.
     }
-  }
-  if (!helper.hasPulseCredentials()) {
-    return;
   }
   // Kill servers
   if (testServer) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -60,11 +60,31 @@ class FakeRoles {
 
 class FakePublisher {
   constructor() {
-    this.publisher = [];
+    this.clients = [];
   }
 
-  async get() {
-    return this.publisher;
+  async clientCreated(clientId) {
+    return Promise.resolve();
+  }
+
+  async clientUpdated(clientId) {
+    return Promise.resolve();
+  }
+
+  async clientDeleted(clientId) {
+    return Promise.resolve();
+  }
+
+  async roleUpdated(clientId) {
+    return Promise.resolve();
+  }
+
+  async roleCreated(clientId) {
+    return Promise.resolve();
+  }
+
+  async roleDeleted(clientId) {
+    return Promise.resolve();
   }
 }
 
@@ -97,73 +117,17 @@ mocha.before(async () => {
     await helper.Roles.setup();
   }
 
-  //overwrites.publisher = await Exchanges.connect({fake:true});
+  overwrites.publisher = new FakePublisher();
+
+  overwrites.resolver = helper.resolver =
+    await serverLoad('resolver', overwrites);
 
   if (!helper.hasPulseCredentials()) {
-    helper.Auth = class {
-      ping() {
-        return Promise.resolve();
-      }
-      client(){
-        return Promise.resolve();
-      }
-      createClient(){
-        helper.events.triggerEvents(helper.authEvents, clientCreated());
-        return Promise.resolve();
-      }
-      deleteClient(){
-        return Promise.resolve();
-      }
-    };
-
-    helper.auth = new helper.Auth();
-
-    helper.authEvents ={
-      clientCreated: () => 'client created',
-      clientDeleted: () => 'client deleted',
-    };
-
-    class EventHandler {
-      constructor() {
-        this.eventCounter = {};
-        this.listener = {};
-      }
-
-      getListenersFromTriggerId (triggerId) {
-        return this.listener[triggerId];
-      }
-
-      listenFor(eventId, triggerId){
-        if (this.listener.hasOwnProperty(triggerId)) {
-          this.listener[triggerId].push(eventId);
-        } else {
-          this.listener[triggerId] = [eventId];
-        }
-        return Promise.resolve();
-      }
-      waitFor(eventId){
-        if (this.eventCounter[eventId] && this.eventCounter[eventId] > 0) {
-          this.eventCounter[eventId]--;
-          return Promise.resolve();
-        } else {
-          return Promise.reject();
-        }
-      }
-
-      clientDeleted(clientId) {
-        return Promise.resolve();
-      }
-    }
-
-    helper.events = new EventHandler();
     return;
   } else {
-    overwrites.resolver = helper.resolver =
-      await serverLoad('resolver', overwrites);
 
     webServer = await serverLoad('server', overwrites);
     webServer.setTimeout(3500); // >3s because Azure can be sloooow
-
     helper.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
     var reference = v1.reference({baseUrl: helper.baseUrl});
     helper.Auth = taskcluster.createClient(reference);

--- a/test/purgeExpiredClients_test.js
+++ b/test/purgeExpiredClients_test.js
@@ -5,15 +5,9 @@ suite('Client.purgeExpired', function() {
 
   const CLIENT_ID = 'nobody/sds:ad_asd/df-sAdSfchsdfsdfs';
 
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  } else {
-    setup(async () => {
-      await helper.auth.deleteClient(CLIENT_ID);
-    });
-  }
+  setup(async () => {
+    await helper.auth.deleteClient(CLIENT_ID);
+  });
 
   const testClient = async ({expires, deleteOnExpiration}) => {
     await helper.auth.createClient(CLIENT_ID, {

--- a/test/remotevalidation_test.js
+++ b/test/remotevalidation_test.js
@@ -9,12 +9,6 @@ suite('Remote Signature Validation', function() {
   var taskcluster = require('taskcluster-client');
   var request     = require('superagent');
 
-  setup(function() {
-    if (!helper.hasPulseCredentials()) {
-      this.skip();
-    }
-  });
-
   var rootCredentials = {
     clientId: 'static/taskcluster/root',
     accessToken: helper.rootAccessToken,

--- a/test/role_test.js
+++ b/test/role_test.js
@@ -9,12 +9,6 @@ suite('api (roles)', function() {
   var testing     = require('taskcluster-lib-testing');
   var taskcluster = require('taskcluster-client');
 
-  setup(function() {
-    if (!helper.hasPulseCredentials()) {
-      this.skip();
-    }
-  });
-
   let sorted = (arr) => {
     arr.sort();
     return arr;
@@ -37,8 +31,6 @@ suite('api (roles)', function() {
   });
 
   test('createRole (normal)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.roleCreated());
-
     let role = await helper.auth.createRole('thing-id:' + clientId, {
       description: 'test role',
       scopes: ['dummy-scope-1', 'auth:create-role:*', 'dummy-scope-2'],
@@ -61,7 +53,7 @@ suite('api (roles)', function() {
     // Ensure that pulse messages comes, don't check the payload as we can't
     // be sure the tests aren't interfering with each other and I'm too lazy to
     // handle all messages.
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'roleCreated', roleId:'thing-id:' + clientId}]);
 
     let client = await helper.auth.client(clientId);
     assume(client.expandedScopes.sort()).deep.equals(
@@ -70,7 +62,6 @@ suite('api (roles)', function() {
   });
 
   test('createRole (prefix)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.roleCreated());
     let auth = new helper.Auth({
       credentials: {clientId, accessToken},
     });
@@ -81,7 +72,7 @@ suite('api (roles)', function() {
       scopes: ['dummy-scope-2'],
     });
 
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'roleCreated', roleId:roleId}]);
 
     assume(role.description).equals('test prefix role');
     assume(new Date(role.created).getTime()).is.atmost(Date.now());
@@ -139,8 +130,6 @@ suite('api (roles)', function() {
   });
 
   test('updateRole (add scope)', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.roleUpdated());
-
     let r1 = await helper.auth.role('thing-id:' + clientId);
 
     await testing.sleep(100);
@@ -152,7 +141,7 @@ suite('api (roles)', function() {
     assume(new Date(r2.lastModified).getTime()).greaterThan(
       new Date(r1.lastModified).getTime()
     );
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{method: 'roleUpdated', roleId:'thing-id:' + clientId}]);
 
     let role = await helper.auth.role('thing-id:' + clientId);
     assume(role.expandedScopes.sort()).deep.equals([
@@ -165,8 +154,6 @@ suite('api (roles)', function() {
   });
 
   test('deleteRole', async () => {
-    await helper.events.listenFor('e1', helper.authEvents.roleDeleted());
-
     await helper.auth.deleteRole('thing-id:' + clientId);
     await helper.auth.deleteRole('thing-id:' + clientId);
     let roleId = 'thing-id:' + clientId.slice(0, 11) + '*';
@@ -177,7 +164,8 @@ suite('api (roles)', function() {
     }, err => assert(err.statusCode === 404, 'Expected 404'));
 
     // At least one of them should trigger this message
-    await helper.events.waitFor('e1');
+    assert.deepEqual(helper.publisher.calls, [{
+      method: 'roleDeleted', roleId:'thing-id:' + clientId}, {method: 'roleDeleted', roleId:roleId}]);
   });
 
   test('create a role introducing a parameter cycle', async () => {
@@ -210,40 +198,33 @@ suite('api (roles)', function() {
     let roleId2 = `sub-thing:${clientId}`;
     let auth;
 
-    if (!helper.hasPulseCredentials()) {
-      setup(function() {
-        this.skip();
+    setup(async function() {
+      auth = new helper.Auth({
+        credentials: {clientId: 'root', accessToken: helper.rootAccessToken},
+        authorizedScopes: [
+          'auth:update-role:*',
+          'scope:role-has:a',
+          'scope:caller-has:a',
+          'scope:caller-has:b*',
+        ],
       });
-    } else {
-      setup(async function() {
-        auth = new helper.Auth({
-          credentials: {clientId: 'static/taskcluster/root', accessToken: helper.rootAccessToken},
-          authorizedScopes: [
-            'auth:update-role:*',
-            'scope:role-has:a',
-            'scope:caller-has:a',
-            'scope:caller-has:b*',
-          ],
-        });
+      // clear stuff out
+      await helper.Roles.modify((roles) => roles.splice(0));
 
-        // clear stuff out
-        await helper.Roles.modify((roles) => roles.splice(0));
-
-        await helper.auth.createRole(roleId, {
-          description: 'a role',
-          scopes: ['scope:role-has:*', `assume:${roleId2}`],
-        });
-
-        await helper.auth.createRole(roleId2, {
-          description: 'another role',
-          scopes: ['scope:sub-role-has:*'],
-        });
+      await helper.auth.createRole(roleId, {
+        description: 'a role',
+        scopes: ['scope:role-has:*', `assume:${roleId2}`],
       });
 
-      teardown(async function() {
-        await helper.Roles.modify((roles) => roles.splice(0));
+      await helper.auth.createRole(roleId2, {
+        description: 'another role',
+        scopes: ['scope:sub-role-has:*'],
       });
-    }
+    });
+
+    teardown(async function() {
+      await helper.Roles.modify((roles) => roles.splice(0));
+    });
 
     test('caller has new scope verbatim', async () => {
       await auth.updateRole(roleId, {

--- a/test/role_test.js
+++ b/test/role_test.js
@@ -200,7 +200,10 @@ suite('api (roles)', function() {
 
     setup(async function() {
       auth = new helper.Auth({
-        credentials: {clientId: 'root', accessToken: helper.rootAccessToken},
+        credentials: {
+          clientId: 'static/taskcluster/root',
+          accessToken: helper.rootAccessToken,
+        },
         authorizedScopes: [
           'auth:update-role:*',
           'scope:role-has:a',

--- a/test/rolelogic_test.js
+++ b/test/rolelogic_test.js
@@ -6,12 +6,6 @@ suite('api (role logic)', function() {
   var taskcluster = require('taskcluster-client');
   var mocha       = require('mocha');
 
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  }
-
   /**
    * Customized test function, taking an object as follows:
    * test('...', {

--- a/test/s3_test.js
+++ b/test/s3_test.js
@@ -9,12 +9,6 @@ suite('aws S3 (STS)', () => {
 
   var bucket = helper.cfg.test.testBucket;
 
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  }
-
   test('awsS3Credentials read-write folder1/folder2/', async () => {
     var id    = slugid.v4();
     var text  = slugid.v4();

--- a/test/statsum_test.js
+++ b/test/statsum_test.js
@@ -2,12 +2,6 @@ suite('statsum', () => {
   let helper = require('./helper');
   let assert = require('assert');
 
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  }
-
   test('statsumToken', async () => {
     let result = await helper.auth.statsumToken('test');
 

--- a/test/testauth_test.js
+++ b/test/testauth_test.js
@@ -106,12 +106,6 @@ suite('testAuthenticate', function() {
 });
 
 suite('testAuthenticateGet', function() {
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  }
-
   let testAuthGet = (name, {config, errorCode}) => {
     test(name, async () => {
       let auth = new helper.Auth(config);

--- a/test/webhooktunnel_test.js
+++ b/test/webhooktunnel_test.js
@@ -3,12 +3,6 @@ suite('webhooktunnel', () => {
   let assert = require('assert');
   let jwt = require('jsonwebtoken');
 
-  if (!helper.hasPulseCredentials()) {
-    setup(function() {
-      this.skip();
-    });
-  }
-
   test('webhooktunnelToken', async () => {
     let {tunnelId, token, proxyUrl} = await helper.auth.webhooktunnelToken();
     let decoded = jwt.verify(token, 'test-secret');


### PR DESCRIPTION
It is done by creating fake helper attributes

Related to Bug 1436799

@djmitche please review,  i tried to run the clienttest without credentials, so I commented the part which have !havePulseCredentials, then I look at each test, what methods they need and try to add it