### PR TITLE
Cleaned up schemas to improve generated go types in taskcluster-client-go

### DIFF
--- a/schemas/authenticate-hawk-request.yml
+++ b/schemas/authenticate-hawk-request.yml
@@ -43,9 +43,10 @@ properties:
       **Note,** order of querystring elements is important.
   host:
     type:                 string
-    anyOf:
-      - format:           hostname
-      - format:           ipv4
+    # IPv4 addresses conform to `hostname` format according to jsonschema, so
+    # we do not need to specify both `hostname` and `ipv4` formats.
+    format:               hostname
+    title:                Hostname or IPv4
     description: |
       Host for which the request came in, this is typically the `Host` header
       excluding the port if any.

--- a/schemas/azure-container-response.yml
+++ b/schemas/azure-container-response.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:    "Azure Blob Shared-Access-Signature Response"
+title:    "Azure Blob Shared-Access-Signature"
 description: |
   Response to a request for an Shared-Access-Signature to access an Azure
   Blob Storage container.

--- a/schemas/azure-table-access-response.yml
+++ b/schemas/azure-table-access-response.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:                      "Azure Table Shared-Access-Signature Response"
+title:                      "Azure Table Shared-Access-Signature"
 description: |
   Response to a request for an Shared-Access-Signature to access and Azure
   Table Storage table.


### PR DESCRIPTION
This names types to avoid that we generate types `Var`, `Var1`, `Var2`, `Var3` when using non-nested structs in taskcluster-client-go.

Names that are too long are discarded, so this shortens two names that were too long, and also gives names to `oneOf` subtypes.