### PR TITLE
Bug 1457608: Make signatures work in heroku and kubernetes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -95,6 +95,9 @@ defaults:
     # Trust a forwarding proxy
     trustProxy:               !env:bool TRUST_PROXY
 
+    # TODO: pick a better name for this
+    proxyName:                !env PROXY_NAME
+
   azure:
     # Azure table storage account name
     accountName:              !env AZURE_ACCOUNT_NAME

--- a/src/main.js
+++ b/src/main.js
@@ -218,7 +218,7 @@ let load = Loader({
       let serverApp = App(Object.assign({}, {docs}, cfg.server));
 
       serverApp.use(morganDebug('auth-request', 'dev'));
-      serverApp.use('/v1', api);
+      serverApp.use(`${cfg.server.proxyName || ''}/v1`, api);
 
       serverApp.get('/', (req, res) => {
         res.redirect(302, url.format({


### PR DESCRIPTION
This hacks the things to work in both places. I have not put much thought into any of the names or whatever of this, but at least it works? I think this will fail tests and stuff still. Just getting it out there for our monday discussion.