### PR TITLE
Increase length of project names to allow for standardizing on projectName

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -81,7 +81,7 @@ var api = new API({
     // doesn't work well with HTTPS and virtual-style hosting.
     // Hence, we shouldn't encourage people to use them
     // Project for sentry (and other per project resources)
-    project:    /^[a-zA-Z0-9_-]{1,22}$/,
+    project:    /^[a-zA-Z0-9_-]{1,64}$/,
   },
   context: [
     // Instances of data tables


### PR DESCRIPTION
Currently we limit this to 22 chars and I think we only do that for "consistency". We end up having lots of weird project names to fit into this limit. May as well raise it?

**NOTE: We must set TASKCLUSTER_ROOT_URL env var to `https://taskcluster.net` before we deploy this**