### PR TITLE
Bug 1440965 - enforce scopes don't end in **

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -33,3 +33,15 @@ wildcard, matching any suffix. So `queue:create-task:test-provisioner/*`
 satisfies `queue:create-task:test-provisioner/worker3`. The reverse is not
 true. The wildcard only works at the end of a string: no more advanced
 pattern-matching functionality is available.
+
+### Double-Stars
+
+The scope `foo:**` satisfies, on its face, any scope beginning with `foo:*`, including `foo:*123` and `foo:*` but not `foo:abc`.
+If scope `foo:**` is used to create a temporary credential with `foo:*`, the operation will succeed (`foo:**` satisfies `foo:*`).
+But the resulting temporary credential has `foo:*`, which *does* satisfy `foo:abc`, unlike the original credential.
+In fact, this can occur anywhere a scope is delegated, including temporary credentials, authorizedScopes, task creation, client creation, and role creation.
+
+The issue is a minor one, though, if we think of a scope ending with `**` (or any number of stars greater than one) as equivalent to a scope ending with a single star.
+
+Taskcluster encourages this perspective by prohibiting scopes ending with `**` in clients and roles, and when creating tasks.
+Instead, use the single-star form, avoiding any ambiguity.

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -14,3 +14,12 @@ slugid-pattern: "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9
 message-version:
   enum: [1]
   description: Message version number
+
+scope:
+    type: string
+    name: Scope
+    description: |
+      A single scope. A scope must be composed of
+      printable ASCII characters and spaces.  Scopes ending in more than
+      one `*` character are forbidden.
+    pattern: "^[\x20-\x7e]*(?<!\\*\\*)$"

--- a/schemas/v1/create-client-request.yml
+++ b/schemas/v1/create-client-request.yml
@@ -24,13 +24,9 @@ properties:
     maxLength:              10240
   scopes:
     description: |
-      List of scopes the client has.  Scopes must be composed of
-      printable ASCII characters and spaces.
+      List of scopes the client has (unexpanded).
     type:                   array
-    items:
-      description: Scope
-      type:                 string
-      pattern: "^[\x20-\x7e]*$"
+    items: {$const: scope}
     uniqueItems:            true
 additionalProperties:       false
 required:

--- a/schemas/v1/create-client-response.yml
+++ b/schemas/v1/create-client-response.yml
@@ -57,25 +57,17 @@ properties:
     format:                 date-time
   scopes:
     description: |
-      List of scopes the client has (unexpanded).  Scopes must be composed of
-      printable ASCII characters and spaces.
+      List of scopes the client has (unexpanded).
     type:                   array
     default:                []
-    items:
-      description: Scope
-      type:                 string
-      pattern: "^[\x20-\x7e]*$"
+    items: {$const: scope}
     uniqueItems:            true
   expandedScopes:
     description: |
       List of scopes granted to this client by matching roles, including the
       client's scopes and the implicit role `client-id:<clientId>`.
     type:                   array
-    items:
-      description: |
-        Scope that client is granted
-      type:                 string
-      pattern: "^[\x20-\x7e]*$"
+    items: {$const: scope}
   disabled:
     description: |
       If true, this client is disabled and cannot be used.  This usually occurs when the

--- a/schemas/v1/create-role-request.yml
+++ b/schemas/v1/create-role-request.yml
@@ -9,11 +9,7 @@ properties:
       List of scopes the role grants access to.  Scopes must be composed of
       printable ASCII characters and spaces.
     type:                   array
-    items:
-      description: |
-        Scope the role grants access to
-      type:                 string
-      pattern: "^[\x20-\x7e]*$"
+    items: {$const: scope}
     uniqueItems:            true
   description:
     description: |

--- a/schemas/v1/get-role-response.yml
+++ b/schemas/v1/get-role-response.yml
@@ -14,11 +14,7 @@ properties:
       List of scopes the role grants access to.  Scopes must be composed of
       printable ASCII characters and spaces.
     type:                   array
-    items:
-      description: |
-        Scope the role grants access to
-      type:                 string
-      pattern:              "^[\x20-\x7e]*$"
+    items: {$const: scope}
   description:
     description: |
       Description of what this role is used for in markdown.
@@ -42,11 +38,7 @@ properties:
       granted by roles that can be assumed when you have this role.
       Hence, this includes any scopes in-directly granted as well.
     type:                   array
-    items:
-      description: |
-        Scope this role grants
-      type:                 string
-      pattern:              "^[\x20-\x7e]*$"
+    items: {$const: scope}
 additionalProperties:       false
 required:
   - roleId

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -111,6 +111,20 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
     helper.checkNextMessage('client-created', m => assert.equal(m.payload.clientId, CLIENT_ID));
   });
 
+  test('create client with a **-scope', async () => {
+    try {
+      await helper.apiClient.createClient(CLIENT_ID, {
+        expires: taskcluster.fromNow('1 hour'),
+        description: 'client',
+        scopes: ['scope1:**'],
+      });
+    } catch (err) {
+      assert.equal(err.code, 'InputValidationError');
+      return;
+    }
+    assert(false, 'Expected an error');
+  });
+
   const createTestClient = async () => {
     let expires = taskcluster.fromNow('1 hour');
     let description = 'Test client...';
@@ -236,6 +250,20 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
     assume(client2.expandedScopes).not.contains('scope1');
     assume(client2.expandedScopes).contains('scope2');
     assume(client2.expandedScopes).contains('scope3');
+  });
+
+  test('update client adding a **-scope', async () => {
+    try {
+      await helper.apiClient.updateClient(CLIENT_ID, {
+        expires: taskcluster.fromNow('1 hour'),
+        description: 'client',
+        scopes: ['scope1:**'],
+      });
+    } catch (err) {
+      assert.equal(err.code, 'InputValidationError');
+      return;
+    }
+    assert(false, 'Expected an error');
   });
 
   test('auth.disableClient / enableClient', async () => {

--- a/test/role_test.js
+++ b/test/role_test.js
@@ -115,6 +115,14 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
     await helper.apiClient.deleteRole('test*');
   });
 
+  test('createRole with a **-scope', async () => {
+    await helper.apiClient.createRole('other', {
+      description: 'other',
+      scopes: ['foo:***'],
+    }).then(() => assert(false, 'Expected error'),
+      err => assert(err.statusCode === 400, 'Expected 400'));
+  });
+
   test('getRole', async () => {
     let role = await helper.apiClient.role('thing-id:' + clientId);
     assume(role.expandedScopes.sort()).deep.equals([
@@ -128,6 +136,14 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
   test('listRoles', async () => {
     let roles = await helper.apiClient.listRoles();
     assert(roles.some(role => role.roleId === 'thing-id:' + clientId));
+  });
+
+  test('updateRole with a **-scope', async () => {
+    await helper.apiClient.updateRole('thing-id:' + clientId, {
+      description: 'other',
+      scopes: ['foo:***'],
+    }).then(() => assert(false, 'Expected error'),
+      err => assert(err.statusCode === 400, 'Expected 400'));
   });
 
   test('updateRole (add scope)', async () => {


### PR DESCRIPTION
@petemoore can you double-check that the golang regexp engine will handle the negative lookbehind here?