### PR TITLE
Add sourceIp to auditlog log line

### DIFF
--- a/schemas/v1/authenticate-hawk-request.yml
+++ b/schemas/v1/authenticate-hawk-request.yml
@@ -63,6 +63,13 @@ properties:
     description: |
       Authorization header, **must** only be specified if request being
       authenticated has a `Authorization` header.
+  sourceIp:
+    type:                 string
+    format:               ipv4
+    title:                Source IP
+    description: |
+      Source IP of the authentication request or request that requires
+      authentication. This is only used for audit logging.
 additionalProperties:     false
 required:
   - method

--- a/src/signaturevalidator.js
+++ b/src/signaturevalidator.js
@@ -181,7 +181,7 @@ const limitClientWithExt = function(credentialName, issuingClientId, accessToken
  * }
  *
  * The function returned takes an object:
- *     {method, resource, host, port, authorization}
+ *     {method, resource, host, port, authorization, sourceIp}
  * And returns promise for an object on one of the forms:
  *     {status: 'auth-failed', message},
  *     {status: 'auth-success', clientId, scheme, scopes}, or
@@ -280,7 +280,7 @@ const createSignatureValidator = function(options) {
         options.monitor.log({
           time: new Date(),
           event: 'signature-validation',
-          version: 2,
+          version: 3,
           expires: credentials? credentials.expires : '',
           scopes: credentials? credentials.scopes : [],
           clientId: credentials? credentials.clientId : '',
@@ -292,6 +292,7 @@ const createSignatureValidator = function(options) {
           port: req.port,
           resource: req.resource,
           method: req.method.toUpperCase(),
+          sourceIp: req.sourceIp,
         });
         return accept(result);
       };

--- a/src/signaturevalidator.js
+++ b/src/signaturevalidator.js
@@ -292,7 +292,7 @@ const createSignatureValidator = function(options) {
           port: req.port,
           resource: req.resource,
           method: req.method.toUpperCase(),
-          sourceIp: req.sourceIp,
+          sourceIp: req.sourceIp || '0.0.0.0',
         });
         return accept(result);
       };

--- a/test/schema-test-data/authenticate-hawk-request-bad.json
+++ b/test/schema-test-data/authenticate-hawk-request-bad.json
@@ -3,5 +3,6 @@
   "resource": "/v1/client/authed-client/credentials?hello=world",
   "host": "this@is@not@valid!",
   "port": 1207,
-  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\""
+  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\"",
+  "sourceIp": "127.0.0.1"
 }

--- a/test/schema-test-data/authenticate-hawk-request-ipv4.json
+++ b/test/schema-test-data/authenticate-hawk-request-ipv4.json
@@ -3,5 +3,6 @@
   "resource": "/v1/client/authed-client/credentials?hello=world",
   "host": "127.0.0.1",
   "port": 1207,
-  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\""
+  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\"",
+  "sourceIp": "127.0.0.1"
 }

--- a/test/schema-test-data/authenticate-hawk-request.json
+++ b/test/schema-test-data/authenticate-hawk-request.json
@@ -3,5 +3,6 @@
   "resource": "/v1/client/authed-client/credentials?hello=world",
   "host": "localhost",
   "port": 1207,
-  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\""
+  "authorization": "Hawk id=\"authed-client\", ts=\"1439419405\", nonce=\"nlSAIZ\", hash=\"B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=\", mac=\"wz6IeHMz83B7IWrWPSo7+0WoSuIO7pzcy5ZyjN7c1So=\"",
+  "sourceIp": "127.0.0.1"
 }

--- a/test/signaturevalidator_test.js
+++ b/test/signaturevalidator_test.js
@@ -57,6 +57,7 @@ suite(helper.suiteName(__filename), function() {
         resource: '/',
         host: 'test.taskcluster.net',
         port: 443,
+        sourceIp: '127.0.0.1',
       });
 
       if (input.authorization) {


### PR DESCRIPTION
Accept `sourceIp` in `createSignatureValidator`'s `options` object and log that parameter within the audit log.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1488545
Related: https://github.com/taskcluster/taskcluster-lib-api/pull/116