### PR TITLE
Bug 1488789 - use tc-lib-pulse

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "lodash": "^4.17.4",
     "morgan-debug": "^2.0.0",
     "promise": "^8.0.1",
-    "pulse-publisher": "^10.0.2",
     "quick-lru": "^1.1.0",
     "sentry-api": "^0.1.1",
     "slugid": "^1.1.0",
@@ -42,6 +41,7 @@
     "taskcluster-lib-iterate": "^10.0.0",
     "taskcluster-lib-loader": "^10.0.1",
     "taskcluster-lib-monitor": "^11.0.1",
+    "taskcluster-lib-pulse": "^2.1.0",
     "taskcluster-lib-scopes": "^10.0.0",
     "taskcluster-lib-validate": "^11.0.2",
     "typed-env-config": "^1.1.0"

--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -1,4 +1,4 @@
-const Exchanges = require('pulse-publisher');
+const {Exchanges} = require('taskcluster-lib-pulse');
 const assert = require('assert');
 
 /** Declaration of exchanges offered by the auth */

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,9 +20,9 @@ const uuid = require('uuid');
 const Builder = require('taskcluster-lib-api');
 const SchemaSet = require('taskcluster-lib-validate');
 const App = require('taskcluster-lib-app');
-const Exchanges = require('pulse-publisher');
 const libUrls = require('taskcluster-lib-urls');
 const {fakeauth, stickyLoader, Secrets} = require('taskcluster-lib-testing');
+const {FakeClient} = require('taskcluster-lib-pulse');
 
 exports.suiteName = path.basename;
 
@@ -244,21 +244,14 @@ exports.withSentry = (mock, skipping) => {
       exports.load.inject('sentryClient', sentryFake);
     }
   });
-
-  suiteTeardown(async () => {
-    if (skipping()) {
-      return;
-    }
-    if (mock) {
-    }
-  });
 };
 
 /**
- * Set up PulsePublisher in fake mode, at helper.publisher. Messages are stored
- * in helper.messages.  The `helper.checkNextMessage` function allows asserting the
- * content of the next message, and `helper.checkNoNextMessage` is an assertion that
- * no such message is in the queue.
+ * Set up tc-lib-pulse in fake mode, with a publisher at at helper.publisher.
+ * Messages are stored in helper.messages.  The `helper.checkNextMessage`
+ * function allows asserting the content of the next message, and
+ * `helper.checkNoNextMessage` is an assertion that no such message is in the
+ * queue.
  */
 exports.withPulse = (mock, skipping) => {
   suiteSetup(async function() {
@@ -266,9 +259,10 @@ exports.withPulse = (mock, skipping) => {
       return;
     }
 
+    exports.load.inject('pulseClient', new FakeClient());
+
     await exports.load('cfg');
     exports.load.cfg('taskcluster.rootUrl', exports.rootUrl);
-    exports.load.cfg('pulse', {fake: true});
     exports.publisher = await exports.load('publisher');
 
     exports.checkNextMessage = (exchange, check) => {
@@ -292,14 +286,14 @@ exports.withPulse = (mock, skipping) => {
     };
   });
 
-  const fakePublish = msg => { exports.messages.push(msg); };
+  const recordMessage = msg => exports.messages.push(msg);
   setup(function() {
     exports.messages = [];
-    exports.publisher.on('fakePublish', fakePublish);
+    exports.publisher.on('message', recordMessage);
   });
 
   teardown(function() {
-    exports.publisher.removeListener('fakePublish', fakePublish);
+    exports.publisher.removeListener('message', recordMessage);
   });
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,7 +65,7 @@ ajv@^6.5.0:
     json-schema-traverse "^0.3.0"
     uri-js "^4.2.1"
 
-amqplib@^0.5.1:
+amqplib@^0.5.1, amqplib@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.5.2.tgz#d2d7313c7ffaa4d10bcf1e6252de4591b6cc7b63"
   integrity sha512-l9mCs6LbydtHqRniRwYkKdqxVa6XMz3Vw1fh+2gJaaVgTM6Jk3o8RccAKWKtlhT1US5sWrFh+KKxsVUALURSIA==
@@ -208,7 +208,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-aws-sdk@^2.142.0, aws-sdk@^2.147.0, aws-sdk@^2.148.0, aws-sdk@^2.150.0, aws-sdk@^2.151.0, aws-sdk@^2.30.0:
+aws-sdk@^2.142.0, aws-sdk@^2.147.0, aws-sdk@^2.150.0, aws-sdk@^2.151.0, aws-sdk@^2.30.0:
   version "2.190.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.190.0.tgz#c7b48b3845345b60795943eb919700cf7edf5734"
   integrity sha1-x7SLOEU0W2B5WUPrkZcAz37fVzQ=
@@ -222,6 +222,21 @@ aws-sdk@^2.142.0, aws-sdk@^2.147.0, aws-sdk@^2.148.0, aws-sdk@^2.150.0, aws-sdk@
     uuid "3.1.0"
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
+
+aws-sdk@^2.331.0:
+  version "2.335.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.335.0.tgz#9e050fe8a01591bb1e7e8e6c928dfe38c90e30b7"
+  integrity sha512-xxFtV/m2I+Jtr7QXpGSOm7i6hmZg262p4BtFG5G5JDcvlq6h4pCdTjTZYmM3Wb8CCwhQ+LPqUoUa2zgt9VJiqQ==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.19"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -939,7 +954,7 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
-events@^1.1.1:
+events@1.1.1, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -1432,7 +1447,7 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
-ieee754@^1.1.4:
+ieee754@1.1.8, ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
   integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
@@ -2229,21 +2244,6 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-pulse-publisher@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/pulse-publisher/-/pulse-publisher-10.0.2.tgz#2c148aa401e617ffaad083ebfeaa43333f203c30"
-  integrity sha512-TsumLQFCRD75oVAbqib66xjiiGxgVIeOklVaqv9rE4nRqjxMqGZfwrDCNW7l3qF+bNXK/Q3bbilGFkqUQGD/kQ==
-  dependencies:
-    ajv "^5.3.0"
-    amqplib "^0.5.1"
-    aws-sdk "^2.148.0"
-    debug "^3.1.0"
-    lodash "^4.0.0"
-    promise "^8.0.1"
-    slugid "^1.1.0"
-    taskcluster-client "^10.0.0"
-    taskcluster-lib-urls "^10.0.0"
-
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -2883,6 +2883,20 @@ taskcluster-client@^11.0.1:
     superagent "~3.8.1"
     taskcluster-lib-urls "^10.0.0"
 
+taskcluster-client@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-11.0.4.tgz#ea8df77d78ac72de5fb087bb6b884a25f33c90ee"
+  integrity sha512-OF98kBaUwsSoe/oX62MIXdFwO7D5NQMbm1W+7vHFfI+HQ5QzWQpfuv1HU/chteJkez6QvFvM0qhXon4a1wKUEA==
+  dependencies:
+    amqplib "^0.5.1"
+    debug "^3.1.0"
+    hawk "^6.0.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
+    slugid "^1.1.0"
+    superagent "~3.8.1"
+    taskcluster-lib-urls "^10.0.0"
+
 taskcluster-client@^3.0.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.2.0.tgz#2a12d31587f9bb5a37262d650525c818a5947767"
@@ -3008,6 +3022,17 @@ taskcluster-lib-monitor@^11.0.1:
     raven "^2.2.1"
     statsum "^0.6.0"
     taskcluster-client "^10.0.0"
+
+taskcluster-lib-pulse@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-pulse/-/taskcluster-lib-pulse-2.1.0.tgz#ba1927cd59f7e83b28530f9d73e92050fae426e3"
+  integrity sha512-NSTC9BoOct+Zjt6O1niqXVOkHi1QulAYSVIJfcz7nI4acbSpMEWz1jwszcmf/dcheX/6oXiywFB8VXF4sCyJGg==
+  dependencies:
+    amqplib "^0.5.2"
+    aws-sdk "^2.331.0"
+    debug "^3.1.0"
+    taskcluster-client "^11.0.4"
+    taskcluster-lib-urls "^10.0.0"
 
 taskcluster-lib-scopes@^10.0.0:
   version "10.0.0"
@@ -3356,12 +3381,25 @@ xml2js@0.4.17:
     sax ">=0.6.0"
     xmlbuilder "^4.1.0"
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
   integrity sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=
   dependencies:
     lodash "^4.0.0"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
For real this time!

 * Use configured pulse credentials, so no dependency on another service
 * Use ephemeral consumers for the "notification" pulse messages
 * Use a regular producer to send those notifications

What am I missing?