### PR TITLE
Fix user-config-example.yml

### DIFF
--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -6,8 +6,8 @@ test:
   test:
     testBucket: "test-bucket-for-any-garbage"
   azure:
-    accountName:  "taskclusterdev"
-    accountKey:   "..."
+    accountId:  "taskclusterdev"
+    accessKey:   "..."
   aws:
     accessKeyId:        "..."
     secretAccessKey:    "..."


### PR DESCRIPTION
Azure has `accountId` and `accessKey` according to https://github.com/taskcluster/taskcluster-auth/blob/master/config.yml#L86-L88.