### PR TITLE
Bug 1508849 - implement **-scope protection differently

### DIFF
--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -22,4 +22,4 @@ scope:
       A single scope. A scope must be composed of
       printable ASCII characters and spaces.  Scopes ending in more than
       one `*` character are forbidden.
-    pattern: "^[\x20-\x7e]*(?<!\\*\\*)$"
+    pattern: "^[\x20-\x7e]*$"

--- a/src/v1.js
+++ b/src/v1.js
@@ -234,6 +234,10 @@ builder.declare({
     );
   }
 
+  if (scopes.some(s => s.endsWith('**'))) {
+    return res.reportError('InputError', 'scopes must not end with `**`', {});
+  }
+
   // Check scopes
   await req.authorize({clientId, scopes});
 
@@ -384,6 +388,10 @@ builder.declare({
       'configured clients. Contact your administrator to change static clients.',
       {clientId},
     );
+  }
+
+  if (input.scopes && input.scopes.some(s => s.endsWith('**'))) {
+    return res.reportError('InputError', 'scopes must not end with `**`', {});
   }
 
   // Load client
@@ -641,6 +649,10 @@ builder.declare({
       {});
   }
 
+  if (input.scopes.some(s => s.endsWith('**'))) {
+    return res.reportError('InputError', 'scopes must not end with `**`', {});
+  }
+
   // Check scopes
   await req.authorize({roleId, scopes: input.scopes});
 
@@ -731,6 +743,10 @@ builder.declare({
     return res.reportError('InputError',
       'Roles are temporarily locked during upgrade',
       {});
+  }
+
+  if (input.scopes.some(s => s.endsWith('**'))) {
+    return res.reportError('InputError', 'scopes must not end with `**`', {});
   }
 
   // Load and modify role

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -119,7 +119,7 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
         scopes: ['scope1:**'],
       });
     } catch (err) {
-      assert.equal(err.code, 'InputValidationError');
+      assert.equal(err.code, 'InputError');
       return;
     }
     assert(false, 'Expected an error');
@@ -260,7 +260,7 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
         scopes: ['scope1:**'],
       });
     } catch (err) {
-      assert.equal(err.code, 'InputValidationError');
+      assert.equal(err.code, 'InputError');
       return;
     }
     assert(false, 'Expected an error');


### PR DESCRIPTION
The old solution used a negative lookbehind, which per
https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions
is not supported in json-schema.  In fact, it's not supported in even
fairly recent versions of Node.  This causes problems when validating
schemas using those old versions of node (or using json-schema
validators that do not support this form).

So, the new solution is to explicitly forbid those forms where used in
creating clients and roles.  The result is much the same, as evidenced
by the minimal changes to the tests.