### PR TITLE
Bug 1509089 - remove LOCK_ROLES support

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -643,12 +643,6 @@ builder.declare({
   const roleId    = req.params.roleId;
   const input     = req.body;
 
-  if (process.env.LOCK_ROLES === 'true') {
-    return res.reportError('InputError',
-      'Roles are temporarily locked during upgrade',
-      {});
-  }
-
   if (input.scopes.some(s => s.endsWith('**'))) {
     return res.reportError('InputError', 'scopes must not end with `**`', {});
   }
@@ -739,12 +733,6 @@ builder.declare({
   const roleId    = req.params.roleId;
   const input     = req.body;
 
-  if (process.env.LOCK_ROLES === 'true') {
-    return res.reportError('InputError',
-      'Roles are temporarily locked during upgrade',
-      {});
-  }
-
   if (input.scopes.some(s => s.endsWith('**'))) {
     return res.reportError('InputError', 'scopes must not end with `**`', {});
   }
@@ -815,12 +803,6 @@ builder.declare({
   ].join('\n'),
 }, async function(req, res) {
   let roleId  = req.params.roleId;
-
-  if (process.env.LOCK_ROLES === 'true') {
-    return res.reportError('InputError',
-      'Roles are temporarily locked during upgrade',
-      {});
-  }
 
   // Check scopes
   await req.authorize({roleId});


### PR DESCRIPTION
This was a big old hack meant to block changes to roles during the
transition to storing roles in a blob.  It's not needed anymore.